### PR TITLE
fix: remove stale cmd.Process.Kill() references after #218 revert

### DIFF
--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -465,14 +465,6 @@ func (s *SimulatorDevice) StartAgent(config StartAgentConfig) error {
 		return err
 	}
 
-	if config.Hook != nil {
-		hookName := fmt.Sprintf("simulator-agent-%s", s.UDID)
-		config.Hook.Register(hookName, func() error {
-			_ = s.TerminateApp(agentRunnerBundleID)
-			return cmd.Process.Kill()
-		})
-	}
-
 	// update WDA client to use the actual port
 	s.wdaClient = wda.NewWdaClient(fmt.Sprintf("localhost:%d", usePort))
 
@@ -483,7 +475,6 @@ func (s *SimulatorDevice) StartAgent(config StartAgentConfig) error {
 	err = s.wdaClient.WaitForAgent()
 	if err != nil {
 		_ = s.TerminateApp(agentRunnerBundleID)
-		_ = cmd.Process.Kill()
 		return err
 	}
 


### PR DESCRIPTION
PR #218 reverted simctl spawn back to LaunchAppWithEnv, but leftover references to cmd were not cleaned up, causing a build failure.