### PR TITLE
fix: launch android apps on emulators with hw.keyboard = no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* Android: Fix launching apps on emulators with `hw.keyboard = no` by passing `--pct-syskeys 0` to monkey
+
 ## [0.3.70](https://github.com/mobile-next/mobilecli/releases/tag/0.3.70) (2026-05-04)
 * iOS: Fix terminating simulator runner and register shutdown hook on agent start ([#217](https://github.com/mobile-next/mobilecli/pull/217))
 * iOS: Update devicekit-ios agent to 0.0.18 ([#220](https://github.com/mobile-next/mobilecli/pull/220))

--- a/devices/android.go
+++ b/devices/android.go
@@ -279,7 +279,7 @@ func (d *AndroidDevice) LaunchApp(bundleID string, locales []string) error {
 		}
 	}
 
-	output, err := d.runAdbCommand("shell", "monkey", "-p", bundleID, "-c", "android.intent.category.LAUNCHER", "1")
+	output, err := d.runAdbCommand("shell", "monkey", "-p", bundleID, "--pct-syskeys", "0", "-c", "android.intent.category.LAUNCHER", "1")
 	if err != nil {
 		return fmt.Errorf("failed to launch app %s: %v\nOutput: %s", bundleID, err, string(output))
 	}


### PR DESCRIPTION
pass --pct-syskeys 0 to monkey to avoid failure when the emulator has no physical keyboard configured (exit status 251).