### PR TITLE
fix: include android elements with non-null resource-id in dump ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.3.73](https://github.com/mobile-next/mobilecli/releases/tag/0.3.73) (2026-05-12)
+* Android: Include elements with `resource-id` in UI element tree dump even when text and content-desc are empty
+
 ## [0.3.72](https://github.com/mobile-next/mobilecli/releases/tag/0.3.72) (2026-05-11)
 * Android: Fix launching apps installed with `-t` (test) flag ([#225](https://github.com/mobile-next/mobilecli/pull/225))
 

--- a/devices/android.go
+++ b/devices/android.go
@@ -1192,7 +1192,7 @@ func (d *AndroidDevice) collectElements(node uiAutomatorXmlNode) []types.ScreenE
 	}
 
 	// process current node if it has text, content-desc, or hint
-	if node.Text != "" || node.ContentDesc != "" || node.Hint != "" {
+	if node.Text != "" || node.ContentDesc != "" || node.Hint != "" || node.ResourceID != "" {
 		rect := d.getScreenElementRect(node.Bounds)
 
 		// only include elements with positive width and height


### PR DESCRIPTION
Elements that have a resource-id but no text, content-desc, or hint are now included in collectElements so automation can target them.