### PR TITLE
feat: use devicekit instrumentation for android view tree dump

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -260,6 +260,13 @@ func findInstalledAgent(device devices.ControllableDevice) *devices.InstalledApp
 	}
 	for _, app := range apps {
 		if app.PackageName == agentPackage {
+			if app.Version == "" {
+				if androidDevice, ok := device.(*devices.AndroidDevice); ok {
+					if v, err := androidDevice.GetAppVersion(agentPackage); err == nil {
+						app.Version = v
+					}
+				}
+			}
 			return &app
 		}
 	}

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	agentVersionIOS     = "0.0.18"
-	agentVersionAndroid = "1.1.5"
+	agentVersionAndroid = "1.2.0"
 	iosRunnerBundleID   = "com.mobilenext.devicekit-iosUITests.xctrunner"
 	androidPackageName  = "com.mobilenext.devicekit"
 )
@@ -25,7 +25,7 @@ var agentChecksums = map[string]string{
 	"devicekit-ios-Sim-arm64.zip":  "445c8e7f5ea95b84e4350ae1930df26f4edfa01a0ceebb1ac3b8b94a26714920",
 	"devicekit-ios-Sim-x86_64.zip": "5e007d70bd6bb94ac71debaea011775ba7d381f616803f1ed66d6eb6b9d49ea4",
 	"devicekit-ios-runner.ipa":     "45457d3f11de2b5370b14ba45e6c8502328e28825ee8222e8517245898a4c57f",
-	"mobilenext-devicekit.apk":     "843c71b81db846ccde7d34c41f3a49a2380d0c1b2acfcbcfafdcd673fadb23ab",
+	"mobilenext-devicekit.apk":     "2d47d820413e9cdfcdd81d44cc0a30ce09d81723d10f2929da8d08b079f5f6d1",
 }
 
 type agentMessageResponse struct {

--- a/devices/android.go
+++ b/devices/android.go
@@ -859,7 +859,7 @@ func (d *AndroidDevice) getForegroundPackageName() (string, error) {
 	return "", fmt.Errorf("could not determine foreground app")
 }
 
-func (d *AndroidDevice) getAppVersion(packageName string) (string, error) {
+func (d *AndroidDevice) GetAppVersion(packageName string) (string, error) {
 	output, err := d.runAdbCommand("shell", "dumpsys", "package", packageName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get package info: %w", err)
@@ -886,7 +886,7 @@ func (d *AndroidDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 		return nil, err
 	}
 
-	version, err := d.getAppVersion(packageName)
+	version, err := d.GetAppVersion(packageName)
 	if err != nil {
 		return nil, err
 	}

--- a/devices/android.go
+++ b/devices/android.go
@@ -148,6 +148,13 @@ func (d *AndroidDevice) runAdbCommand(args ...string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
+func (d *AndroidDevice) runAdbCommandContext(ctx context.Context, args ...string) ([]byte, error) {
+	deviceID := d.getAdbIdentifier()
+	cmdArgs := append([]string{"-s", deviceID}, args...)
+	cmd := exec.CommandContext(ctx, getAdbPath(), cmdArgs...)
+	return cmd.CombinedOutput()
+}
+
 // getDisplayCount counts the number of displays on the device
 func (d *AndroidDevice) getDisplayCount() int {
 	output, err := d.runAdbCommand("shell", "dumpsys", "SurfaceFlinger", "--display-id")
@@ -1303,7 +1310,10 @@ func collectDeviceKitElements(nodes []deviceKitNode) []types.ScreenElement {
 }
 
 func (d *AndroidDevice) getDeviceKitNodes() ([]deviceKitNode, error) {
-	output, err := d.runAdbCommand("shell", "am", "instrument", "-w", "-e", "waitUntilIdle", "2000", "com.mobilenext.devicekit/.ViewTreeDump")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	output, err := d.runAdbCommandContext(ctx, "shell", "am", "instrument", "-w", "-e", "waitUntilIdle", "2000", "com.mobilenext.devicekit/.ViewTreeDump")
 	if err != nil {
 		return nil, fmt.Errorf("devicekit instrument failed: %w", err)
 	}

--- a/devices/android.go
+++ b/devices/android.go
@@ -17,8 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/mobile-next/mobilecli/devices/wda"
 	"github.com/mobile-next/mobilecli/types"
 	"github.com/mobile-next/mobilecli/utils"
@@ -1380,7 +1378,7 @@ func (d *AndroidDevice) DumpSourceRaw() (any, error) {
 	if jsonStr, err := d.getDeviceKitDump(); err == nil {
 		return jsonStr, nil
 	} else {
-		log.Debugf("devicekit dump unavailable, falling back to uiautomator: %v", err)
+		utils.Verbose("devicekit dump unavailable, falling back to uiautomator: %v", err)
 	}
 
 	xmlContent, err := d.getUiAutomatorDump()
@@ -1395,7 +1393,7 @@ func (d *AndroidDevice) DumpSource() ([]ScreenElement, error) {
 	if nodes, err := d.getDeviceKitNodes(); err == nil {
 		return collectDeviceKitElements(nodes), nil
 	} else {
-		log.Debugf("devicekit dump unavailable, falling back to uiautomator: %v", err)
+		utils.Verbose("devicekit dump unavailable, falling back to uiautomator: %v", err)
 	}
 
 	xmlContent, err := d.getUiAutomatorDump()

--- a/devices/android.go
+++ b/devices/android.go
@@ -3,6 +3,7 @@ package devices
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -1161,6 +1162,28 @@ type uiAutomatorXml struct {
 	RootNode uiAutomatorXmlNode `xml:"node"`
 }
 
+type deviceKitRect struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type deviceKitNode struct {
+	Class       string          `json:"class"`
+	Text        string          `json:"text"`
+	ContentDesc string          `json:"content-desc"`
+	ResourceID  string          `json:"resource-id"`
+	Focused     bool            `json:"focused"`
+	Visible     bool            `json:"visible"`
+	Rect        deviceKitRect   `json:"rect"`
+	Children    []deviceKitNode `json:"children"`
+}
+
+type deviceKitHierarchy struct {
+	Hierarchy []deviceKitNode `json:"hierarchy"`
+}
+
 func (d *AndroidDevice) getScreenElementRect(bounds string) types.ScreenElementRect {
 	re := regexp.MustCompile(`^\[(\d+),(\d+)\]\[(\d+),(\d+)\]$`)
 	matches := re.FindStringSubmatch(bounds)
@@ -1233,6 +1256,97 @@ func (d *AndroidDevice) collectElements(node uiAutomatorXmlNode) []types.ScreenE
 	return elements
 }
 
+func collectDeviceKitElements(nodes []deviceKitNode) []types.ScreenElement {
+	var elements []types.ScreenElement
+
+	for _, node := range nodes {
+		elements = append(elements, collectDeviceKitElements(node.Children)...)
+
+		if node.Text == "" && node.ContentDesc == "" && node.ResourceID == "" {
+			continue
+		}
+		if node.Rect.Width <= 0 || node.Rect.Height <= 0 {
+			continue
+		}
+
+		rect := types.ScreenElementRect{
+			X:      node.Rect.X,
+			Y:      node.Rect.Y,
+			Width:  node.Rect.Width,
+			Height: node.Rect.Height,
+		}
+
+		element := types.ScreenElement{
+			Type: node.Class,
+			Text: &node.Text,
+			Rect: rect,
+		}
+
+		if node.ContentDesc != "" {
+			element.Label = &node.ContentDesc
+		}
+		if node.Focused {
+			focused := true
+			element.Focused = &focused
+		}
+		if node.ResourceID != "" {
+			element.Identifier = &node.ResourceID
+		}
+		if element.Type == "" {
+			element.Type = "text"
+		}
+
+		elements = append(elements, element)
+	}
+
+	return elements
+}
+
+func (d *AndroidDevice) getDeviceKitNodes() ([]deviceKitNode, error) {
+	output, err := d.runAdbCommand("shell", "am", "instrument", "-w", "-e", "waitUntilIdle", "2000", "com.mobilenext.devicekit/.ViewTreeDump")
+	if err != nil {
+		return nil, fmt.Errorf("devicekit instrument failed: %w", err)
+	}
+
+	dump := string(output)
+	if strings.Contains(dump, "INSTRUMENTATION_ABORTED") || strings.Contains(dump, "does not have a signature matching") {
+		return nil, fmt.Errorf("devicekit instrument aborted")
+	}
+
+	const prefix = "INSTRUMENTATION_STATUS: json="
+	var allNodes []deviceKitNode
+	for _, line := range strings.Split(dump, "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		var h deviceKitHierarchy
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, prefix)), &h); err != nil {
+			return nil, fmt.Errorf("failed to parse devicekit JSON: %w", err)
+		}
+		allNodes = append(allNodes, h.Hierarchy...)
+	}
+
+	if len(allNodes) == 0 {
+		return nil, fmt.Errorf("no hierarchy found in devicekit dump")
+	}
+
+	return allNodes, nil
+}
+
+func (d *AndroidDevice) getDeviceKitDump() (string, error) {
+	nodes, err := d.getDeviceKitNodes()
+	if err != nil {
+		return "", err
+	}
+
+	jsonBytes, err := json.Marshal(deviceKitHierarchy{Hierarchy: nodes})
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize devicekit hierarchy: %w", err)
+	}
+
+	return string(jsonBytes), nil
+}
+
 func (d *AndroidDevice) getUiAutomatorDump() (string, error) {
 	for tries := 0; tries < 10; tries++ {
 		output, err := d.runAdbCommand("exec-out", "uiautomator", "dump", "/dev/tty")
@@ -1260,37 +1374,34 @@ func (d *AndroidDevice) getUiAutomatorDump() (string, error) {
 }
 
 func (d *AndroidDevice) DumpSourceRaw() (any, error) {
-	// get the XML dump from uiautomator
+	if jsonStr, err := d.getDeviceKitDump(); err == nil {
+		return jsonStr, nil
+	}
+
 	xmlContent, err := d.getUiAutomatorDump()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get uiautomator dump: %w", err)
+		return nil, fmt.Errorf("failed to get view tree dump: %w", err)
 	}
 
 	return xmlContent, nil
 }
 
 func (d *AndroidDevice) DumpSource() ([]ScreenElement, error) {
-	// get the raw XML dump
-	rawData, err := d.DumpSourceRaw()
+	if nodes, err := d.getDeviceKitNodes(); err == nil {
+		return collectDeviceKitElements(nodes), nil
+	}
+
+	xmlContent, err := d.getUiAutomatorDump()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get view tree dump: %w", err)
 	}
 
-	xmlContent, ok := rawData.(string)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type for raw XML data")
-	}
-
-	// parse the XML
 	var uiXml uiAutomatorXml
 	if err := xml.Unmarshal([]byte(xmlContent), &uiXml); err != nil {
 		return nil, fmt.Errorf("failed to parse uiautomator XML: %w", err)
 	}
 
-	// collect elements from the hierarchy
-	elements := d.collectElements(uiXml.RootNode)
-
-	return elements, nil
+	return d.collectElements(uiXml.RootNode), nil
 }
 
 func (d *AndroidDevice) InstallApp(path string) error {

--- a/devices/android.go
+++ b/devices/android.go
@@ -17,6 +17,8 @@ import (
 	"syscall"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mobile-next/mobilecli/devices/wda"
 	"github.com/mobile-next/mobilecli/types"
 	"github.com/mobile-next/mobilecli/utils"
@@ -1316,6 +1318,7 @@ func (d *AndroidDevice) getDeviceKitNodes() ([]deviceKitNode, error) {
 	const prefix = "INSTRUMENTATION_STATUS: json="
 	var allNodes []deviceKitNode
 	for _, line := range strings.Split(dump, "\n") {
+		line = strings.TrimRight(line, "\r")
 		if !strings.HasPrefix(line, prefix) {
 			continue
 		}
@@ -1376,6 +1379,8 @@ func (d *AndroidDevice) getUiAutomatorDump() (string, error) {
 func (d *AndroidDevice) DumpSourceRaw() (any, error) {
 	if jsonStr, err := d.getDeviceKitDump(); err == nil {
 		return jsonStr, nil
+	} else {
+		log.Debugf("devicekit dump unavailable, falling back to uiautomator: %v", err)
 	}
 
 	xmlContent, err := d.getUiAutomatorDump()
@@ -1389,6 +1394,8 @@ func (d *AndroidDevice) DumpSourceRaw() (any, error) {
 func (d *AndroidDevice) DumpSource() ([]ScreenElement, error) {
 	if nodes, err := d.getDeviceKitNodes(); err == nil {
 		return collectDeviceKitElements(nodes), nil
+	} else {
+		log.Debugf("devicekit dump unavailable, falling back to uiautomator: %v", err)
 	}
 
 	xmlContent, err := d.getUiAutomatorDump()


### PR DESCRIPTION
## Summary

- Tries `com.mobilenext.devicekit/.ViewTreeDump` via `am instrument` first for the Android UI element tree dump
- Falls back to `uiautomator dump` if devicekit is not installed or the instrumentation fails
- Parses the JSON output from devicekit (`INSTRUMENTATION_STATUS: json=...`) and maps it to `ScreenElement` the same way uiautomator XML does

## Test plan

- [ ] Device with devicekit installed: verify `DumpSource` returns elements via the new path
- [ ] Device without devicekit: verify fallback to uiautomator still works
- [ ] `dump --format raw` returns JSON string when devicekit is available, XML string otherwise