### PR TITLE
fix: match agent bundle id by suffix to support re-signed runner

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/mobile-next/mobilecli/commands"
@@ -311,7 +312,7 @@ func findInstalledAgent(device devices.ControllableDevice) *devices.InstalledApp
 		return nil
 	}
 	for _, app := range apps {
-		if app.PackageName == agentPackage {
+		if agentMatchesApp(device.Platform(), app.PackageName, agentPackage) {
 			if app.Version == "" {
 				if androidDevice, ok := device.(*devices.AndroidDevice); ok {
 					if v, err := androidDevice.GetAppVersion(agentPackage); err == nil {
@@ -323,6 +324,16 @@ func findInstalledAgent(device devices.ControllableDevice) *devices.InstalledApp
 		}
 	}
 	return nil
+}
+
+// agentMatchesApp reports whether an installed app's bundle id identifies the agent.
+// On iOS the runner bundle id can carry a signing/team prefix when re-signed, so a
+// suffix match is used; other platforms require an exact match.
+func agentMatchesApp(platform, installedPackage, agentPackage string) bool {
+	if platform == "ios" {
+		return strings.HasSuffix(installedPackage, agentPackage)
+	}
+	return installedPackage == agentPackage
 }
 
 func isAgentInstalled(device devices.ControllableDevice) bool {

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -485,10 +485,11 @@ func (d *IOSDevice) StartAgent(config StartAgentConfig) error {
 			return fmt.Errorf("failed to list apps: %w", err)
 		}
 
-		// check if agent is installed
+		// check if agent is installed. the runner bundle id can carry a signing/team
+		// prefix when re-signed, so match on suffix rather than exact equality.
 		agentBundleId := ""
 		for _, app := range apps {
-			if app.PackageName == agentRunnerBundleID {
+			if strings.HasSuffix(app.PackageName, agentRunnerBundleID) {
 				utils.Verbose("agent is installed, launching it")
 				agentBundleId = app.PackageName
 				break

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -290,14 +290,21 @@ func (s SimulatorDevice) WaitUntilAppExists(bundleID string) error {
 	}
 }
 
-func (s SimulatorDevice) IsAgentInstalled() (bool, error) {
+// findInstalledAgentBundleID returns the bundle id of the installed agent, or an
+// empty string if it is not installed. The runner bundle id can carry a
+// signing/team prefix, so it is matched on suffix rather than exact equality.
+func (s SimulatorDevice) findInstalledAgentBundleID() (string, error) {
 	installedApps, err := s.ListInstalledApps()
 	if err != nil {
-		return false, err
+		return "", err
 	}
 
-	_, ok := installedApps[agentRunnerBundleID]
-	return ok, nil
+	for bundleID := range installedApps {
+		if strings.HasSuffix(bundleID, agentRunnerBundleID) {
+			return bundleID, nil
+		}
+	}
+	return "", nil
 }
 
 func (s *SimulatorDevice) getState() (string, error) {
@@ -437,12 +444,12 @@ func (s *SimulatorDevice) StartAgent(config StartAgentConfig) error {
 		utils.Verbose("Failed to get existing WDA port: %v", err)
 	}
 
-	installed, err := s.IsAgentInstalled()
+	agentBundleID, err := s.findInstalledAgentBundleID()
 	if err != nil {
 		return err
 	}
 
-	if !installed {
+	if agentBundleID == "" {
 		return fmt.Errorf("agent is not installed, use 'mobilecli agent install --device %s' to install it", s.UDID)
 	}
 
@@ -462,7 +469,7 @@ func (s *SimulatorDevice) StartAgent(config StartAgentConfig) error {
 		"DEVICEKIT_LISTEN_PORT": strconv.Itoa(usePort),
 	}
 
-	err = s.LaunchAppWithEnv(agentRunnerBundleID, env)
+	err = s.LaunchAppWithEnv(agentBundleID, env)
 	if err != nil {
 		return err
 	}
@@ -476,7 +483,7 @@ func (s *SimulatorDevice) StartAgent(config StartAgentConfig) error {
 
 	err = s.wdaClient.WaitForAgent()
 	if err != nil {
-		_ = s.TerminateApp(agentRunnerBundleID)
+		_ = s.TerminateApp(agentBundleID)
 		return err
 	}
 


### PR DESCRIPTION
## Summary
The agent runner bundle id can carry a signing/team prefix when the runner is re-signed, so an exact bundle-id comparison fails to find an installed agent. Match on suffix instead of exact equality across the iOS device, simulator, and CLI lookup paths.

## Changes
- `cli/agent.go`: add `agentMatchesApp` helper — suffix match on iOS, exact match on other platforms.
- `devices/ios.go`: match installed agent by suffix in `StartAgent`.
- `devices/simulator.go`: replace `IsAgentInstalled` with `findInstalledAgentBundleID`, which returns the actual installed bundle id (suffix-matched) so launch/terminate use the real id.

## Test plan
- [x] Install a re-signed agent (with team prefix) and confirm `agent install`/`start` detects and launches it
- [x] Confirm exact-match still works on Android