### PR TITLE
fix: scale press-keys RPC timeout by key count

### DIFF
--- a/devices/wda/press-keys.go
+++ b/devices/wda/press-keys.go
@@ -1,16 +1,30 @@
 package wda
 
+import "time"
+
 // KeyCombo represents a single key press with optional modifier keys
 type KeyCombo struct {
 	Key       string   `json:"key"`
 	Modifiers []string `json:"modifiers"`
 }
 
+// per-key time budget added on top of the default RPC timeout, since all keys
+// are pressed within a single RPC and the device types them sequentially
+const perKeyTimeout = 2 * time.Second
+
+// maxPressKeysTimeout keeps the request below the http client's own timeout
+const maxPressKeysTimeout = 55 * time.Second
+
 func (c *WdaClient) PressKeys(combos []KeyCombo) error {
 	params := map[string]any{
 		"keys": combos,
 	}
 
-	_, err := c.CallRPC("device.io.keys", params)
+	timeout := defaultRPCTimeout + time.Duration(len(combos))*perKeyTimeout
+	if timeout > maxPressKeysTimeout {
+		timeout = maxPressKeysTimeout
+	}
+
+	_, err := c.CallRPCWithTimeout("device.io.keys", params, timeout)
 	return err
 }

--- a/devices/wda/requests.go
+++ b/devices/wda/requests.go
@@ -31,7 +31,13 @@ type jsonRPCError struct {
 	Message string `json:"message"`
 }
 
+const defaultRPCTimeout = 10 * time.Second
+
 func (c *WdaClient) CallRPC(method string, params any) (json.RawMessage, error) {
+	return c.CallRPCWithTimeout(method, params, defaultRPCTimeout)
+}
+
+func (c *WdaClient) CallRPCWithTimeout(method string, params any, timeout time.Duration) (json.RawMessage, error) {
 	rpcReq := jsonRPCRequest{
 		JSONRPC: "2.0",
 		Method:  method,
@@ -46,7 +52,7 @@ func (c *WdaClient) CallRPC(method string, params any) (json.RawMessage, error) 
 
 	url := fmt.Sprintf("%s/rpc", c.baseURL)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))


### PR DESCRIPTION
## Summary
All keys in a `PressKeys` call are sent within a single RPC and typed sequentially on the device, so a long key sequence could exceed the fixed 10s RPC timeout. Scale the timeout by the number of keys, capped below the HTTP client's own timeout.

## Changes
- `devices/wda/requests.go`: extract `defaultRPCTimeout` (10s) and add `CallRPCWithTimeout`; `CallRPC` now delegates to it.
- `devices/wda/press-keys.go`: compute timeout as `defaultRPCTimeout + len(combos) * 2s`, capped at 55s, and call via `CallRPCWithTimeout`.

## Test plan
- [x] Press a long key sequence and confirm it no longer times out
- [x] Confirm short sequences still behave as before