### PR TITLE
chore: update devicekit-ios agent to 0.0.20

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	agentVersionIOS     = "0.0.19"
+	agentVersionIOS     = "0.0.20"
 	agentVersionAndroid = "1.2.2"
 	iosRunnerBundleID   = "com.mobilenext.devicekit-iosUITests.xctrunner"
 	androidPackageName  = "com.mobilenext.devicekit"
@@ -23,9 +23,9 @@ const (
 
 // pinned SHA-256 checksums for agent artifacts, keyed by download filename
 var agentChecksums = map[string]string{
-	"devicekit-ios-Sim-arm64.zip":  "125ad3fd09284842f9ee038297e4da5e798a53caaa726f77ce4eef2864922041",
-	"devicekit-ios-Sim-x86_64.zip": "9c23379d96808f4ecf7c99009c66c047e5108e709bb572d3a4418e0ab21b12e2",
-	"devicekit-ios-runner.ipa":     "8057833c136911d9edcd559ad65578f595d3b8f48a399adc3389cdc8c2201bc0",
+	"devicekit-ios-Sim-arm64.zip":  "8040f4918892f63d79713b5824184ac5f296c5ec9b23266c25af34777550f28c",
+	"devicekit-ios-Sim-x86_64.zip": "78a8f2d208a22523efbaa5cb2a735557e807f877bb8ec1a1c31c886f2e425684",
+	"devicekit-ios-runner.ipa":     "f5fe88d4169c39001ed012101651c5ac00e8ab54aefb72c74455e7037c2e8205",
 	"mobilenext-devicekit.apk":     "c58484b40db6ab84c7445ccaa346ee0804e155e37507a42f1ac37b92a52bdd4f",
 }
 


### PR DESCRIPTION
## Summary

Bumps the pinned iOS agent to devicekit-ios `0.0.20` and updates the SHA-256 checksums for the downloaded artifacts.

- `agentVersionIOS`: `0.0.19` → `0.0.20`
- Updated pinned checksums (sourced from the [0.0.20 release](https://github.com/mobile-next/devicekit-ios/releases/tag/0.0.20) asset digests):
  - `devicekit-ios-Sim-arm64.zip`
  - `devicekit-ios-Sim-x86_64.zip`
  - `devicekit-ios-runner.ipa`

Android agent version and checksum are unchanged.

## Test plan

- [x] `go build ./...` passes
- [x] `mobilecli agent install` downloads 0.0.20 artifacts and checksum verification passes