### PR TITLE
fix: include clickable and checkable elements in android view tree dump

### DIFF
--- a/devices/android.go
+++ b/devices/android.go
@@ -1326,6 +1326,9 @@ func (d *AndroidDevice) EnsureDeviceKitInstalled() error {
 	return nil
 }
 
+// attrTrue is the string value uiautomator uses for boolean node attributes.
+const attrTrue = "true"
+
 type uiAutomatorXmlNode struct {
 	XMLName     xml.Name             `xml:"node"`
 	Class       string               `xml:"class,attr"`
@@ -1335,6 +1338,8 @@ type uiAutomatorXmlNode struct {
 	Focused     string               `xml:"focused,attr"`
 	ContentDesc string               `xml:"content-desc,attr"`
 	ResourceID  string               `xml:"resource-id,attr"`
+	Clickable   string               `xml:"clickable,attr"`
+	Checkable   string               `xml:"checkable,attr"`
 	Nodes       []uiAutomatorXmlNode `xml:"node"`
 }
 
@@ -1405,8 +1410,9 @@ func (d *AndroidDevice) collectElements(node uiAutomatorXmlNode) []types.ScreenE
 		childElements = append(childElements, d.collectElements(childNode)...)
 	}
 
-	// only include the current node if it has text, content-desc, or hint
-	if node.Text == "" && node.ContentDesc == "" && node.Hint == "" && node.ResourceID == "" {
+	// only include the current node if it has text, content-desc, hint,
+	// resource-id, or is interactable (clickable or checkable)
+	if node.Text == "" && node.ContentDesc == "" && node.Hint == "" && node.ResourceID == "" && node.Clickable != attrTrue && node.Checkable != attrTrue {
 		return childElements
 	}
 
@@ -1432,7 +1438,7 @@ func (d *AndroidDevice) collectElements(node uiAutomatorXmlNode) []types.ScreenE
 	}
 
 	// set focused if true
-	if node.Focused == "true" {
+	if node.Focused == attrTrue {
 		focused := true
 		element.Focused = &focused
 	}

--- a/devices/android_elements_test.go
+++ b/devices/android_elements_test.go
@@ -253,6 +253,65 @@ func TestCollectElementsFilledFieldKeepsTextAndPlaceholder(t *testing.T) {
 	}
 }
 
+// An unlabeled but interactable node (e.g. an empty EditText) carries no text,
+// content-desc, hint or resource-id, but should still be returned because the
+// user can interact with it.
+func TestCollectElementsKeepsUnlabeledClickableAndCheckableNodes(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:  "android.widget.FrameLayout",
+		Bounds: "[0,0][1080,2400]",
+		Nodes: []uiAutomatorXmlNode{
+			{
+				Class:     "android.widget.EditText",
+				Clickable: "true",
+				Bounds:    "[84,2155][996,2302]",
+			},
+			{
+				Class:     "android.widget.CheckBox",
+				Checkable: "true",
+				Bounds:    "[84,2344][996,2400]",
+			},
+		},
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 2 {
+		t.Fatalf("expected 2 elements (clickable EditText, checkable CheckBox), got %d: %+v", len(output), output)
+	}
+	if output[0].Type != "android.widget.EditText" {
+		t.Errorf("expected clickable EditText to be kept, got %+v", output[0])
+	}
+	if output[1].Type != "android.widget.CheckBox" {
+		t.Errorf("expected checkable CheckBox to be kept, got %+v", output[1])
+	}
+}
+
+// A node with no text, content-desc, hint, resource-id, and no interactable
+// flags carries no useful signal and should be filtered out.
+func TestCollectElementsDropsUnlabeledNonInteractableNodes(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:  "android.widget.FrameLayout",
+		Bounds: "[0,0][1080,2400]",
+		Nodes: []uiAutomatorXmlNode{
+			{
+				Class:     "android.view.View",
+				Clickable: "false",
+				Checkable: "false",
+				Bounds:    "[0,0][1080,200]",
+			},
+		},
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 0 {
+		t.Fatalf("expected unlabeled non-interactable node to be dropped, got %d: %+v", len(output), output)
+	}
+}
+
 // devicekit sends a separate hint field; it becomes the placeholder, and the
 // masked password text is preserved.
 func TestCollectDeviceKitElementsHintBecomesPlaceholder(t *testing.T) {


### PR DESCRIPTION
## Summary

The Android view tree dump (`collectElements` in `devices/android.go`) only kept a node if it had `text`, `content-desc`, `hint`, or `resource-id`. This dropped unlabeled-but-interactable controls — most notably empty `EditText` input fields — making them invisible to consumers of the dump even though a user clearly needs to interact with them.

This was surfaced by a bug report about a missing element in an Android view tree. On a real Priceline checkout screen, two empty `EditText` fields (one flagged `NAF="true"` by uiautomator, i.e. "not accessibility friendly") were silently filtered out.

## Change

Keep a node if it is interactable, in addition to the existing text/identity checks:

- Added `Clickable` and `Checkable` fields to `uiAutomatorXmlNode`.
- A node is now retained when `clickable="true"` **or** `checkable="true"`, even with no textual signal.
- Introduced an `attrTrue` constant for the `"true"` attribute value (also applied to the existing `focused` check) to keep the literal DRY.

mobile-mcp already keeps `checkable="true"` nodes; this brings mobilecli in line and additionally retains `clickable` nodes. Worth porting the `clickable` part back to mobile-mcp to keep the two aligned.

## Test plan

- [x] `TestCollectElementsKeepsUnlabeledClickableAndCheckableNodes` — unlabeled clickable EditText and checkable CheckBox are returned
- [x] `TestCollectElementsDropsUnlabeledNonInteractableNodes` — unlabeled, non-interactable node is still filtered out
- [x] Existing `TestCollectElements*` tests still pass
- [x] `go build ./...` clean
- [x] `go test ./devices/ -race` passes