### PR TITLE
refactor: rename sessionId → allocationId in fleet allocation API

### DIFF
--- a/cli/fleet.go
+++ b/cli/fleet.go
@@ -79,27 +79,27 @@ Name supports wildcard prefix matching:
 			}
 
 			if result.IsAllocating() {
-				utils.Verbose("waiting for device allocation, session %s (0 seconds elapsed)", result.SessionID)
+				utils.Verbose("waiting for device allocation, session %s (0 seconds elapsed)", result.AllocationID)
 				start := time.Now()
 				deadline := start.Add(time.Duration(fleetTimeout) * time.Second)
 				for {
 					if time.Now().After(deadline) {
-						err := fmt.Errorf("timed out waiting for device allocation after %d seconds (session %s)", fleetTimeout, result.SessionID)
+						err := fmt.Errorf("timed out waiting for device allocation after %d seconds (session %s)", fleetTimeout, result.AllocationID)
 						printJson(commands.NewErrorResponse(err))
 						return err
 					}
 					time.Sleep(5 * time.Second)
 					elapsed := int(time.Since(start).Seconds())
-					utils.Verbose("waiting for device allocation, session %s (%d seconds elapsed)", result.SessionID, elapsed)
-					device, err := commands.FleetGetDeviceBySession(token, result.SessionID)
+					utils.Verbose("waiting for device allocation, session %s (%d seconds elapsed)", result.AllocationID, elapsed)
+					device, err := commands.FleetGetDeviceBySession(token, result.AllocationID)
 					if err != nil {
-						err = fmt.Errorf("failed to check device status (session %s): %w", result.SessionID, err)
+						err = fmt.Errorf("failed to check device status (session %s): %w", result.AllocationID, err)
 						printJson(commands.NewErrorResponse(err))
 						return err
 					}
 					if device.State != "allocating" {
 						response = commands.NewSuccessResponse(commands.FleetAllocateResponse{
-							SessionID:   result.SessionID,
+							AllocationID: result.AllocationID,
 							ProvisionID: result.ProvisionID,
 							State:       device.State,
 							Device: commands.FleetAllocateDevice{

--- a/cli/remote.go
+++ b/cli/remote.go
@@ -78,27 +78,27 @@ Name supports wildcard prefix matching:
 			}
 
 			if result.IsAllocating() {
-				utils.Verbose("waiting for device allocation, session %s (0 seconds elapsed)", result.SessionID)
+				utils.Verbose("waiting for device allocation, session %s (0 seconds elapsed)", result.AllocationID)
 				start := time.Now()
 				deadline := start.Add(time.Duration(fleetTimeout) * time.Second)
 				for {
 					if time.Now().After(deadline) {
-						err := fmt.Errorf("timed out waiting for device allocation after %d seconds (session %s)", fleetTimeout, result.SessionID)
+						err := fmt.Errorf("timed out waiting for device allocation after %d seconds (session %s)", fleetTimeout, result.AllocationID)
 						printJson(commands.NewErrorResponse(err))
 						return err
 					}
 					time.Sleep(5 * time.Second)
 					elapsed := int(time.Since(start).Seconds())
-					utils.Verbose("waiting for device allocation, session %s (%d seconds elapsed)", result.SessionID, elapsed)
-					device, err := commands.FleetGetDeviceBySession(token, result.SessionID)
+					utils.Verbose("waiting for device allocation, session %s (%d seconds elapsed)", result.AllocationID, elapsed)
+					device, err := commands.FleetGetDeviceBySession(token, result.AllocationID)
 					if err != nil {
-						err = fmt.Errorf("failed to check device status (session %s): %w", result.SessionID, err)
+						err = fmt.Errorf("failed to check device status (session %s): %w", result.AllocationID, err)
 						printJson(commands.NewErrorResponse(err))
 						return err
 					}
 					if device.State != "allocating" {
 						response = commands.NewSuccessResponse(commands.FleetAllocateResponse{
-							SessionID:   result.SessionID,
+							AllocationID: result.AllocationID,
 							ProvisionID: result.ProvisionID,
 							State:       device.State,
 							Device: commands.FleetAllocateDevice{

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -30,10 +30,10 @@ type FleetAllocateDevice struct {
 }
 
 type FleetAllocateResponse struct {
-	SessionID   string              `json:"sessionId"`
-	Device      FleetAllocateDevice `json:"device"`
-	ProvisionID string              `json:"provisionId,omitempty"`
-	State       string              `json:"state,omitempty"`
+	AllocationID string              `json:"allocationId"`
+	Device       FleetAllocateDevice `json:"device"`
+	ProvisionID  string              `json:"provisionId,omitempty"`
+	State        string              `json:"state,omitempty"`
 }
 
 func (r FleetAllocateResponse) IsAllocating() bool {
@@ -93,7 +93,7 @@ func FleetGetDeviceBySession(token, sessionID string) (*devices.DeviceInfo, erro
 
 	for _, d := range result.Devices {
 		var p devices.DeviceProvider
-		if json.Unmarshal(d.Provider, &p) == nil && p.SessionID == sessionID {
+		if json.Unmarshal(d.Provider, &p) == nil && p.AllocationID == sessionID {
 			return &d, nil
 		}
 	}

--- a/devices/common.go
+++ b/devices/common.go
@@ -271,7 +271,7 @@ type DeviceListOptions struct {
 
 type DeviceProvider struct {
 	Type      string `json:"type"`
-	SessionID string `json:"sessionId,omitempty"`
+	AllocationID string `json:"allocationId,omitempty"`
 }
 
 type DeviceInfo struct {


### PR DESCRIPTION
## Summary

Updates mobilecli to match the server-side rename of `sessionId` → `allocationId` in the fleet allocation wire format.

## Changes

- `commands/remote.go` — `FleetAllocateResponse.SessionID` → `AllocationID` (`json:"allocationId"`); `DeviceProvider.SessionID` → `AllocationID` (`json:"allocationId,omitempty"`)
- `devices/common.go` — `DeviceProvider.SessionID` → `AllocationID`
- `cli/fleet.go`, `cli/remote.go` — all `result.SessionID` and struct literal field references updated

## Related

Mirrors the backend change in mobile-next/backend#243.