### PR TITLE
fix(server): thread locales through device.apps.launch JSON-RPC handler

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -639,9 +639,10 @@ type DumpUIParams struct {
 }
 
 type AppsLaunchParams struct {
-	DeviceID string `json:"deviceId"`
-	BundleID string `json:"bundleId"`
-	Activity string `json:"activity,omitempty"`
+	DeviceID string   `json:"deviceId"`
+	BundleID string   `json:"bundleId"`
+	Locales  []string `json:"locales,omitempty"`
+	Activity string   `json:"activity,omitempty"`
 }
 
 type AppsTerminateParams struct {
@@ -945,6 +946,7 @@ func handleAppsLaunch(params json.RawMessage) (any, error) {
 	req := commands.AppRequest{
 		DeviceID: appsLaunchParams.DeviceID,
 		BundleID: appsLaunchParams.BundleID,
+		Locales:  appsLaunchParams.Locales,
 		Activity: appsLaunchParams.Activity,
 	}
 


### PR DESCRIPTION
The JSON-RPC `device.apps.launch` handler dropped the `locales` param: `AppsLaunchParams` had no `Locales` field and the `commands.AppRequest` it built never set one. Launching with a locale over JSON-RPC (the path mobilefleet uses) was a silent no-op — the CLI path was unaffected. Adds the field and threads it through.