### PR TITLE
Extend write deadline for app install/uninstall RPCs

### DIFF
--- a/server/deadline_test.go
+++ b/server/deadline_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// Slow, device-side RPCs must get an extended write deadline. Without it they run
+// under the default WriteTimeout, and any call that outlives it has its connection
+// closed mid-response — the caller then sees an opaque EOF instead of the result.
+// device.apps.install was missing from this set, which caused real install failures
+// on devices where the install took longer than the default WriteTimeout.
+func TestExtendedWriteDeadlineForSlowMethods(t *testing.T) {
+	slowMethods := map[string]time.Duration{
+		"device.boot":              3 * time.Minute,
+		"device.apps.install":      3 * time.Minute,
+		"device.apps.uninstall":    3 * time.Minute,
+		"device.screenrecord.stop": 35 * time.Second,
+	}
+
+	for method, want := range slowMethods {
+		got, ok := extendedWriteDeadline(method)
+		if !ok {
+			t.Errorf("%s: expected an extended write deadline, got none", method)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: expected deadline %s, got %s", method, want, got)
+		}
+	}
+}
+
+// Fast methods run under the default WriteTimeout and must not be extended.
+func TestNoExtendedWriteDeadlineForFastMethods(t *testing.T) {
+	for _, method := range []string{"device.info", "device.screenshot", "device.io.tap", ""} {
+		if d, ok := extendedWriteDeadline(method); ok {
+			t.Errorf("%q: expected no extension, got %s", method, d)
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -288,6 +288,22 @@ func StartServer(addr string, enableCORS bool) error {
 	}
 }
 
+// extendedWriteDeadline reports how long the HTTP write deadline should be
+// extended for a given RPC method, and whether an extension applies at all.
+// Some methods perform slow device-side work (booting a device, installing or
+// uninstalling an app) that routinely exceeds the default WriteTimeout. Without
+// an extension the server closes the connection mid-response, which the caller
+// sees as an opaque EOF instead of the real result.
+func extendedWriteDeadline(method string) (time.Duration, bool) {
+	switch method {
+	case "device.boot", "device.apps.install", "device.apps.uninstall":
+		return 3 * time.Minute, true
+	case "device.screenrecord.stop":
+		return 35 * time.Second, true
+	}
+	return 0, false
+}
+
 func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -315,12 +331,11 @@ func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	var result any
 	var err error
 
-	// HTTP-specific: extend timeout for long-running operations
-	switch req.Method {
-	case "device.boot":
-		_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(3 * time.Minute))
-	case "device.screenrecord.stop":
-		_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(35 * time.Second))
+	// HTTP-specific: extend the write deadline for long-running operations so a
+	// slow device-side call can't trip the default WriteTimeout and close the
+	// connection mid-response (which the caller sees as an EOF).
+	if d, ok := extendedWriteDeadline(req.Method); ok {
+		_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(d))
 	}
 
 	// Use registry for all methods


### PR DESCRIPTION
## Summary

`device.apps.install` (and `device.apps.uninstall`) run under the HTTP server's default **10s `WriteTimeout`** because they were never added to the per-method write-deadline extension in `handleJSONRPC`. On devices where an install legitimately takes longer than 10s, the server hits the write deadline and closes the connection mid-response. The caller — `mobilefleet-client` — sees an opaque:

```
mobilecli call failed: Post "http://localhost:12000/rpc": EOF
```

…and reports the install as failed, **even when the app is valid** (it installs fine from the web portal). Because the error is a bare transport EOF, it reads like a bad app rather than a timeout, which is exactly how it was mis-triaged.

## Evidence

From production logs, install outcomes over 2 days:

| Outcome | Attempts | avg | min | max |
|---|---|---|---|---|
| success | 30 | 4.9s | 0s | **10s** |
| fail (EOF) | 11 | 19.9s | **11s** | 68s |

A clean split at the 10s boundary: **every** success finished ≤10s, **every** EOF failure took ≥11s — the signature of the `WriteTimeout` firing. The mobilecli process stays alive throughout (its heartbeat RPCs keep succeeding), so it isn't a crash; only the long install request is severed. `mobilefleet-client`'s own RPC client timeout is 5 minutes, so it is not the limiter.

## Fix

`device.boot` already extends the write deadline to 3 minutes for exactly this reason; install/uninstall are just as slow and were simply missing from the list. This adds them, and refactors the per-method deadlines into a small, testable `extendedWriteDeadline()` helper so a slow method can't be silently omitted again.

## Testing

- `go test ./server/` — full package green, including two new tests (`TestExtendedWriteDeadlineForSlowMethods`, `TestNoExtendedWriteDeadlineForFastMethods`).
- `go vet ./server/`, `gofmt` clean.

## Notes / scope

- This stops installs from being killed at 10s. It does **not** make genuinely slow installs faster — if some devices take 60s+, that's a separate device-provisioning question worth its own look.
- The truly robust design is async install + poll rather than one long synchronous request, but that's a larger change across mobilecli and mobilefleet-client and isn't needed to stop the failures now.
- A complementary `mobilefleet-client` change (classify the transport EOF distinctly from a real install rejection so it isn't reported as a generic "Install failed") is worth doing separately.

https://claude.ai/code/session_01NTmaydwxEmvPEYdiK3Q4yS
