### PR TITLE
chore: skip coderabbit review for docs-only changes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_filters:
+    - "!**/*.md"
+    - "!docs/**"
+    - "!LICENSE"


### PR DESCRIPTION
Adds `.coderabbit.yaml` with path filters excluding markdown, `docs/`, and `LICENSE`.

Docs-only PRs now leave nothing for CodeRabbit to review — it posts a "review skipped" note instead of a full review. Code changes are unaffected.