### PR TITLE
chore: update changelog for 0.3.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.88](https://github.com/mobile-next/mobilecli/releases/tag/0.3.88) (2026-07-29)
+* Fix: Remote mobilenext.ai device allocation response change ([#309](https://github.com/mobile-next/mobilecli/pull/309))
+* Fix: Thread locales through device.apps.launch JSON-RPC handler ([#303](https://github.com/mobile-next/mobilecli/pull/303))
+* Fix: Extend write deadline for app install/uninstall RPCs ([#304](https://github.com/mobile-next/mobilecli/pull/304)), thanks to [@mobile-kevin](https://github.com/mobile-kevin)
+
 ## [0.3.87](https://github.com/mobile-next/mobilecli/releases/tag/0.3.87) (2026-07-15)
 * Feat: Add mobilecli skill ([#256](https://github.com/mobile-next/mobilecli/pull/256)), thanks to [@lazynoda](https://github.com/lazynoda)
 * Fix: Include multiline TextView in iOS accessibility dump ([#294](https://github.com/mobile-next/mobilecli/pull/294)), thanks to [@Ernest94](https://github.com/Ernest94)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [0.3.88](https://github.com/mobile-next/mobilecli/releases/tag/0.3.88) (2026-07-29)
 * Fix: Remote mobilenext.ai device allocation response change ([#309](https://github.com/mobile-next/mobilecli/pull/309))
 * Fix: Thread locales through device.apps.launch JSON-RPC handler ([#303](https://github.com/mobile-next/mobilecli/pull/303))
-* Fix: Extend write deadline for app install/uninstall RPCs ([#304](https://github.com/mobile-next/mobilecli/pull/304)), thanks to [@mobile-kevin](https://github.com/mobile-kevin)
+* Fix: Extend write deadline for app install/uninstall RPCs ([#304](https://github.com/mobile-next/mobilecli/pull/304))
 
 ## [0.3.87](https://github.com/mobile-next/mobilecli/releases/tag/0.3.87) (2026-07-15)
 * Feat: Add mobilecli skill ([#256](https://github.com/mobile-next/mobilecli/pull/256)), thanks to [@lazynoda](https://github.com/lazynoda)


### PR DESCRIPTION
## Changes included

* Fix: Remote mobilenext.ai device allocation response change (#309)
* Fix: Thread locales through device.apps.launch JSON-RPC handler (#303)
* Fix: Extend write deadline for app install/uninstall RPCs (#304), thanks to @mobile-kevin

## Omitted as not user-facing

* #312 — wda → devicekit package rename
* #311 — skip coderabbit review for docs-only changes
* #310 — roadmap docs
* #307 — test coverage report fix
