### PR TITLE
feat: report enabled and checked state in android ui dump

### DIFF
--- a/devices/android.go
+++ b/devices/android.go
@@ -1340,6 +1340,8 @@ type uiAutomatorXmlNode struct {
 	ResourceID  string               `xml:"resource-id,attr"`
 	Clickable   string               `xml:"clickable,attr"`
 	Checkable   string               `xml:"checkable,attr"`
+	Checked     string               `xml:"checked,attr"`
+	Enabled     string               `xml:"enabled,attr"`
 	Nodes       []uiAutomatorXmlNode `xml:"node"`
 }
 
@@ -1362,6 +1364,8 @@ type deviceKitNode struct {
 	ContentDesc string          `json:"content-desc"`
 	ResourceID  string          `json:"resource-id"`
 	Focused     bool            `json:"focused"`
+	Enabled     bool            `json:"enabled"`
+	Checked     bool            `json:"checked"`
 	Visible     bool            `json:"visible"`
 	Rect        deviceKitRect   `json:"rect"`
 	Children    []deviceKitNode `json:"children"`
@@ -1443,6 +1447,19 @@ func (d *AndroidDevice) collectElements(node uiAutomatorXmlNode) []types.ScreenE
 		element.Focused = &focused
 	}
 
+	// set enabled if false; uiautomator omits the attribute for some nodes,
+	// so treat "false" explicitly rather than "not true"
+	if node.Enabled == "false" {
+		enabled := false
+		element.Enabled = &enabled
+	}
+
+	// set checked if true
+	if node.Checked == attrTrue {
+		checked := true
+		element.Checked = &checked
+	}
+
 	// set identifier from resource-id
 	if node.ResourceID != "" {
 		element.Identifier = &node.ResourceID
@@ -1494,6 +1511,14 @@ func collectDeviceKitElements(nodes []deviceKitNode) []types.ScreenElement {
 		if node.Focused {
 			focused := true
 			element.Focused = &focused
+		}
+		if !node.Enabled {
+			enabled := false
+			element.Enabled = &enabled
+		}
+		if node.Checked {
+			checked := true
+			element.Checked = &checked
 		}
 		if node.ResourceID != "" {
 			element.Identifier = &node.ResourceID

--- a/devices/android_elements_test.go
+++ b/devices/android_elements_test.go
@@ -338,3 +338,142 @@ func TestCollectDeviceKitElementsHintBecomesPlaceholder(t *testing.T) {
 		t.Errorf("expected text '•', got %q", got)
 	}
 }
+
+// A disabled node (enabled="false") must still be reported, with Enabled set
+// to false so callers can tell it apart from an interactable one.
+func TestCollectElementsMarksDisabledNode(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:      "android.widget.Button",
+		Text:       "DISABLED BUTTON",
+		ResourceID: "com.mobilenext.playground:id/disabled_button",
+		Clickable:  "true",
+		Enabled:    "false",
+		Bounds:     "[48,1666][1232,1834]",
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Enabled == nil || *output[0].Enabled != false {
+		t.Errorf("expected Enabled to be false, got %+v", output[0].Enabled)
+	}
+}
+
+// An enabled node must leave Enabled unset (nil), matching the omitempty
+// convention already used for Focused.
+func TestCollectElementsLeavesEnabledNodeUnset(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:      "android.widget.Button",
+		Text:       "ENABLED BUTTON",
+		ResourceID: "com.mobilenext.playground:id/enabled_button",
+		Clickable:  "true",
+		Enabled:    "true",
+		Bounds:     "[48,1666][1232,1834]",
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Enabled != nil {
+		t.Errorf("expected Enabled to be nil for an enabled node, got %+v", *output[0].Enabled)
+	}
+}
+
+// devicekit reports enabled as a real bool; a disabled node must surface
+// Enabled=false the same way the uiautomator path does.
+func TestCollectDeviceKitElementsMarksDisabledNode(t *testing.T) {
+	nodes := []deviceKitNode{
+		{
+			Class:      "android.widget.Button",
+			Text:       "DISABLED BUTTON",
+			ResourceID: "com.mobilenext.playground:id/disabled_button",
+			Enabled:    false,
+			Rect:       deviceKitRect{X: 48, Y: 1666, Width: 1184, Height: 168},
+		},
+	}
+
+	output := collectDeviceKitElements(nodes)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Enabled == nil || *output[0].Enabled != false {
+		t.Errorf("expected Enabled to be false, got %+v", output[0].Enabled)
+	}
+}
+
+// A checked Switch (checked="true") must surface Checked=true.
+func TestCollectElementsMarksCheckedSwitch(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:       "android.widget.Switch",
+		ContentDesc: "toggle",
+		ResourceID:  "com.mobilenext.playground:id/toggle",
+		Clickable:   "true",
+		Checkable:   "true",
+		Checked:     "true",
+		Bounds:      "[1050,1196][1190,1277]",
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Checked == nil || *output[0].Checked != true {
+		t.Errorf("expected Checked to be true, got %+v", output[0].Checked)
+	}
+}
+
+// An unchecked Switch must leave Checked unset (nil), matching the
+// omitempty convention already used for Focused and Enabled.
+func TestCollectElementsLeavesUncheckedSwitchUnset(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:       "android.widget.Switch",
+		ContentDesc: "toggle",
+		ResourceID:  "com.mobilenext.playground:id/toggle",
+		Clickable:   "true",
+		Checkable:   "true",
+		Checked:     "false",
+		Bounds:      "[1050,1196][1190,1277]",
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Checked != nil {
+		t.Errorf("expected Checked to be nil for an unchecked switch, got %+v", *output[0].Checked)
+	}
+}
+
+// devicekit reports checked as a real bool; a checked node must surface
+// Checked=true the same way the uiautomator path does.
+func TestCollectDeviceKitElementsMarksCheckedNode(t *testing.T) {
+	nodes := []deviceKitNode{
+		{
+			Class:       "android.widget.Switch",
+			ContentDesc: "toggle",
+			ResourceID:  "com.mobilenext.playground:id/toggle",
+			Checked:     true,
+			Rect:        deviceKitRect{X: 1050, Y: 1196, Width: 140, Height: 81},
+		},
+	}
+
+	output := collectDeviceKitElements(nodes)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Checked == nil || *output[0].Checked != true {
+		t.Errorf("expected Checked to be true, got %+v", output[0].Checked)
+	}
+}

--- a/types/screen.go
+++ b/types/screen.go
@@ -17,5 +17,7 @@ type ScreenElement struct {
 	Identifier  *string           `json:"identifier,omitempty"`
 	Rect        ScreenElementRect `json:"rect"`
 	Focused     *bool             `json:"focused,omitempty"` // currently only on android tv
+	Enabled     *bool             `json:"enabled,omitempty"` // only set when false
+	Checked     *bool             `json:"checked,omitempty"` // only set when true
 	Children    []ScreenElement   `json:"children,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Android's `dump ui` silently dropped whether an element was disabled or a Switch/checkbox was checked — neither `enabled` nor `checked` were parsed from the uiautomator XML or devicekit JSON sources.
- Adds `Enabled *bool` (omitted when true) and `Checked *bool` (omitted when false) to `ScreenElement`, populated on both the uiautomator XML path and the devicekit JSON path in `devices/android.go`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New unit tests in `devices/android_elements_test.go` covering disabled/enabled and checked/unchecked nodes on both dump paths
- [x] Verified on device (`./mobilecli dump ui --device Pixel_9_Pro`): a disabled button now reports `"enabled": false`, and a checked Switch now reports `"checked": true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Screen element data now reports when an element is disabled.
  - Screen element data now reports checked states for controls such as switches.

- **Bug Fixes**
  - Improved consistency of enabled and checked state reporting across Android UI sources.

- **Tests**
  - Added coverage for enabled, disabled, checked, and unchecked element states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->