### PR TITLE
feat: report selected state in android ui dump

### DIFF
--- a/devices/android.go
+++ b/devices/android.go
@@ -1342,6 +1342,7 @@ type uiAutomatorXmlNode struct {
 	Checkable   string               `xml:"checkable,attr"`
 	Checked     string               `xml:"checked,attr"`
 	Enabled     string               `xml:"enabled,attr"`
+	Selected    string               `xml:"selected,attr"`
 	Nodes       []uiAutomatorXmlNode `xml:"node"`
 }
 
@@ -1366,6 +1367,7 @@ type deviceKitNode struct {
 	Focused     bool            `json:"focused"`
 	Enabled     bool            `json:"enabled"`
 	Checked     bool            `json:"checked"`
+	Selected    bool            `json:"selected"`
 	Visible     bool            `json:"visible"`
 	Rect        deviceKitRect   `json:"rect"`
 	Children    []deviceKitNode `json:"children"`
@@ -1460,6 +1462,12 @@ func (d *AndroidDevice) collectElements(node uiAutomatorXmlNode) []types.ScreenE
 		element.Checked = &checked
 	}
 
+	// set selected if true (single-select controls: tabs, chips, radio-style pickers)
+	if node.Selected == attrTrue {
+		selected := true
+		element.Selected = &selected
+	}
+
 	// set identifier from resource-id
 	if node.ResourceID != "" {
 		element.Identifier = &node.ResourceID
@@ -1519,6 +1527,10 @@ func collectDeviceKitElements(nodes []deviceKitNode) []types.ScreenElement {
 		if node.Checked {
 			checked := true
 			element.Checked = &checked
+		}
+		if node.Selected {
+			selected := true
+			element.Selected = &selected
 		}
 		if node.ResourceID != "" {
 			element.Identifier = &node.ResourceID

--- a/devices/android_elements_test.go
+++ b/devices/android_elements_test.go
@@ -477,3 +477,73 @@ func TestCollectDeviceKitElementsMarksCheckedNode(t *testing.T) {
 		t.Errorf("expected Checked to be true, got %+v", output[0].Checked)
 	}
 }
+
+// A selected node (e.g. a chosen tab / chip / radio-style option) must surface
+// Selected=true. Compose maps `semantics { selected = true }` to the
+// accessibility selected state, which uiautomator dumps as selected="true".
+func TestCollectElementsMarksSelectedNode(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:       "android.view.View",
+		ContentDesc: "9:16",
+		ResourceID:  "com.mobilenext.playground:id/ratio_9_16",
+		Clickable:   "true",
+		Selected:    "true",
+		Bounds:      "[0,0][140,140]",
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Selected == nil || *output[0].Selected != true {
+		t.Errorf("expected Selected to be true, got %+v", output[0].Selected)
+	}
+}
+
+// An unselected node must leave Selected unset (nil), matching the omitempty
+// convention already used for Focused, Enabled and Checked.
+func TestCollectElementsLeavesUnselectedNodeUnset(t *testing.T) {
+	d := &AndroidDevice{}
+	tree := uiAutomatorXmlNode{
+		Class:       "android.view.View",
+		ContentDesc: "1:1",
+		ResourceID:  "com.mobilenext.playground:id/ratio_1_1",
+		Clickable:   "true",
+		Selected:    "false",
+		Bounds:      "[140,0][280,140]",
+	}
+
+	output := d.collectElements(tree)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Selected != nil {
+		t.Errorf("expected Selected to be nil for an unselected node, got %+v", *output[0].Selected)
+	}
+}
+
+// devicekit reports selected as a real bool; a selected node must surface
+// Selected=true the same way the uiautomator path does.
+func TestCollectDeviceKitElementsMarksSelectedNode(t *testing.T) {
+	nodes := []deviceKitNode{
+		{
+			Class:       "android.view.View",
+			ContentDesc: "9:16",
+			ResourceID:  "com.mobilenext.playground:id/ratio_9_16",
+			Selected:    true,
+			Rect:        deviceKitRect{X: 0, Y: 0, Width: 140, Height: 140},
+		},
+	}
+
+	output := collectDeviceKitElements(nodes)
+
+	if len(output) != 1 {
+		t.Fatalf("expected 1 element, got %d: %+v", len(output), output)
+	}
+	if output[0].Selected == nil || *output[0].Selected != true {
+		t.Errorf("expected Selected to be true, got %+v", output[0].Selected)
+	}
+}

--- a/types/screen.go
+++ b/types/screen.go
@@ -16,8 +16,9 @@ type ScreenElement struct {
 	Placeholder *string           `json:"placeholder,omitempty"`
 	Identifier  *string           `json:"identifier,omitempty"`
 	Rect        ScreenElementRect `json:"rect"`
-	Focused     *bool             `json:"focused,omitempty"` // currently only on android tv
-	Enabled     *bool             `json:"enabled,omitempty"` // only set when false
-	Checked     *bool             `json:"checked,omitempty"` // only set when true
+	Focused     *bool             `json:"focused,omitempty"`  // currently only on android tv
+	Enabled     *bool             `json:"enabled,omitempty"`  // only set when false
+	Checked     *bool             `json:"checked,omitempty"`  // only set when true
+	Selected    *bool             `json:"selected,omitempty"` // only set when true
 	Children    []ScreenElement   `json:"children,omitempty"`
 }


### PR DESCRIPTION
## Summary

Android's `dump ui` reports `enabled` / `checked` / `focused` but not **`selected`**. Single-select controls — tabs, chips, segmented buttons, radio-style option pickers, anything using Compose `semantics { selected = ... }` (→ `AccessibilityNodeInfo.isSelected()`) — therefore can't be asserted for their selected state.

- Adds `Selected *bool` (omitted when false, matching the `Checked` convention) to `ScreenElement`.
- Populates it on **both** dump paths in `devices/android.go`: the uiautomator XML path (`selected="true"` attr) and the devicekit JSON path.

Exactly parallel to the `enabled`/`checked` handling added in #317.

## Pairs with

Driver-side mapping already merged in [mobile-next/mobilewright#252](https://github.com/mobile-next/mobilewright/pull/252), which maps this through to `ViewNode.isSelected` so `expect(locator).toBeSelected()` works once the agent emits the field. This PR is the remaining agent half.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./types/ ./devices/`
- [x] New unit tests in `devices/android_elements_test.go` covering selected / unselected nodes on both the uiautomator and devicekit dump paths (mirrors the enabled/checked tests from #317).

CI (`go test ./...`) exercises the on-device dex build I can't run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Screen elements now indicate when they are selected.
  * Selection state is supported across Android UI hierarchy sources.
  * Unselected elements omit the selection indicator for cleaner screen data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->