### PR TITLE
chore(ci): update actions to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -47,7 +47,7 @@ jobs:
         ANDROID_HOME: /usr/local/lib/android/sdk
 
     - name: Upload Android agent binaries
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: android-agents
         path: |
@@ -67,7 +67,7 @@ jobs:
       run: make -C agents/ios all
 
     - name: Upload iOS agent binaries
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: ios-agents
         path: |
@@ -84,18 +84,18 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
     - name: Download Android agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: android-agents
         path: agents/android/
 
     - name: Download iOS agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: ios-agents
         path: agents/ios/
@@ -114,7 +114,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
@@ -142,7 +142,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
@@ -164,18 +164,18 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
     - name: Download Android agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: android-agents
         path: agents/android/
 
     - name: Download iOS agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: ios-agents
         path: agents/ios/
@@ -200,7 +200,7 @@ jobs:
         ./mobilecli-darwin-arm64 --version
 
     - name: Upload macos build artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: macos-build
         path: |
@@ -222,18 +222,18 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
     - name: Download Android agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: android-agents
         path: agents/android/
 
     - name: Download iOS agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: ios-agents
         path: agents/ios/
@@ -259,7 +259,7 @@ jobs:
         ./mobilecli-linux-amd64 --version
 
     - name: Upload macos build artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: linux-build
         path: |
@@ -281,19 +281,19 @@ jobs:
         persist-credentials: false
 
     - name: Download Android agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: android-agents
         path: agents/android/
 
     - name: Download iOS agent binaries
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: ios-agents
         path: agents/ios/
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
@@ -312,7 +312,7 @@ jobs:
         $env:GOARCH="arm64"; go build -ldflags="-s -w" -o mobilecli-windows-arm64.exe
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: windows-build
         path: |
@@ -330,7 +330,7 @@ jobs:
         persist-credentials: false
 
     - name: Download macos build
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: macos-build
         path: .
@@ -368,19 +368,19 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Download darwin build
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: macos-build
         path: mobilecli-darwin
 
     - name: Download linux build
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: linux-build
         path: mobilecli-linux
 
     - name: Download windows build
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: windows-build
         path: mobilecli-windows


### PR DESCRIPTION
## Summary
- upgrade actions/setup-go from v5 to v6
- upgrade actions/setup-java from v4 to v5
- upgrade artifact upload and download actions from v5 to v6
- remove Node.js 20 deprecation warnings across all build jobs

## Verification
- parsed .github/workflows/build.yml as YAML
- confirmed no deprecated action versions remain
- make test