### PR TITLE
fix: make remote allocate --name accept a single value

### DIFF
--- a/cli/filters.go
+++ b/cli/filters.go
@@ -60,7 +60,7 @@ func parseNameFilter(value string) (commands.DeviceFilter, error) {
 }
 
 // buildAllocateFilters builds a filters slice from CLI flag values.
-func buildAllocateFilters(platform, deviceType string, versions, names []string) ([]commands.DeviceFilter, error) {
+func buildAllocateFilters(platform, deviceType string, versions []string, name string) ([]commands.DeviceFilter, error) {
 	var filters []commands.DeviceFilter
 
 	filters = append(filters, commands.DeviceFilter{
@@ -85,10 +85,10 @@ func buildAllocateFilters(platform, deviceType string, versions, names []string)
 		filters = append(filters, f)
 	}
 
-	for _, n := range names {
-		f, err := parseNameFilter(n)
+	if name != "" {
+		f, err := parseNameFilter(name)
 		if err != nil {
-			return nil, fmt.Errorf("invalid --name %q: %w", n, err)
+			return nil, fmt.Errorf("invalid --name %q: %w", name, err)
 		}
 		filters = append(filters, f)
 	}

--- a/cli/filters_test.go
+++ b/cli/filters_test.go
@@ -91,7 +91,7 @@ func TestParseNameFilter_JustWildcard(t *testing.T) {
 }
 
 func TestBuildAllocateFilters_PlatformOnly(t *testing.T) {
-	filters, err := buildAllocateFilters("ios", "", nil, nil)
+	filters, err := buildAllocateFilters("ios", "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestBuildAllocateFilters_PlatformOnly(t *testing.T) {
 }
 
 func TestBuildAllocateFilters_WithType(t *testing.T) {
-	filters, err := buildAllocateFilters("ios", "real", nil, nil)
+	filters, err := buildAllocateFilters("ios", "real", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestBuildAllocateFilters_WithType(t *testing.T) {
 }
 
 func TestBuildAllocateFilters_Combined(t *testing.T) {
-	filters, err := buildAllocateFilters("ios", "real", []string{">=18", "<20"}, []string{"iPhone*"})
+	filters, err := buildAllocateFilters("ios", "real", []string{">=18", "<20"}, "iPhone*")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -29,7 +29,7 @@ var (
 	// for remote allocate command
 	fleetType     string
 	fleetVersions []string
-	fleetNames    []string
+	fleetName     string
 	fleetWait     bool
 	fleetTimeout  int
 

--- a/cli/remote.go
+++ b/cli/remote.go
@@ -34,7 +34,7 @@ var remoteAllocateCmd = &cobra.Command{
 	Short: "Allocate a remote device",
 	Long: `Allocates a device from the remote fleet matching the given filters.
 
-Flags --version and --name can be specified multiple times (all are ANDed).
+Flag --version can be specified multiple times (all are ANDed).
 
 Version supports comparison operators:
   --version ">=18"    (greater than or equal)
@@ -54,7 +54,7 @@ Name supports wildcard prefix matching:
 			return err
 		}
 
-		filters, err := buildAllocateFilters(platform, fleetType, fleetVersions, fleetNames)
+		filters, err := buildAllocateFilters(platform, fleetType, fleetVersions, fleetName)
 		if err != nil {
 			return err
 		}
@@ -191,7 +191,7 @@ func init() {
 	_ = remoteAllocateCmd.MarkFlagRequired("platform")
 	remoteAllocateCmd.Flags().StringVar(&fleetType, "type", "", "device type (real)")
 	remoteAllocateCmd.Flags().StringArrayVar(&fleetVersions, "version", nil, "OS version filter (supports >=, >, <=, < prefixes)")
-	remoteAllocateCmd.Flags().StringArrayVar(&fleetNames, "name", nil, "device name filter (supports trailing * for prefix match)")
+	remoteAllocateCmd.Flags().StringVar(&fleetName, "name", "", "device name filter (supports trailing * for prefix match)")
 	remoteAllocateCmd.Flags().BoolVar(&fleetWait, "wait", false, "wait for device to finish allocating before returning")
 	remoteAllocateCmd.Flags().IntVar(&fleetTimeout, "timeout", 900, "seconds to wait for allocation (only used with --wait)")
 


### PR DESCRIPTION
## Summary
- `mobilecli remote allocate --name` previously accepted the flag multiple times and ANDed all values together, which has no logical use since a device can only have one name.
- Changed `--name` from a repeatable string-array flag to a plain string flag; repeating it now just keeps the last value like any normal string flag. `--version` is untouched since ANDing version comparisons (e.g. `>=18` and `<20`) is meaningful.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cli/...`