### PR TITLE
feat(io): add keyboard status and hide commands (android)

### DIFF
--- a/cli/io.go
+++ b/cli/io.go
@@ -198,6 +198,40 @@ var ioSwipeCmd = &cobra.Command{
 	},
 }
 
+var ioKeyboardCmd = &cobra.Command{
+	Use:   "keyboard",
+	Short: "On-screen keyboard operations",
+	Long:  `Query or dismiss the on-screen keyboard on a device.`,
+}
+
+var ioKeyboardStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check whether the on-screen keyboard is visible",
+	Long:  `Reports whether the on-screen keyboard is currently visible on the specified device.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		response := commands.KeyboardStatusCommand(commands.KeyboardRequest{DeviceID: deviceId})
+		printJson(response)
+		if response.Status == "error" {
+			return fmt.Errorf("%s", response.Error)
+		}
+		return nil
+	},
+}
+
+var ioKeyboardHideCmd = &cobra.Command{
+	Use:   "hide",
+	Short: "Hide the on-screen keyboard",
+	Long:  `Dismisses the on-screen keyboard on the specified device.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		response := commands.KeyboardHideCommand(commands.KeyboardRequest{DeviceID: deviceId})
+		printJson(response)
+		if response.Status == "error" {
+			return fmt.Errorf("%s", response.Error)
+		}
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(ioCmd)
 
@@ -208,6 +242,11 @@ func init() {
 	ioCmd.AddCommand(ioTextCmd)
 	ioCmd.AddCommand(ioKeysCmd)
 	ioCmd.AddCommand(ioSwipeCmd)
+	ioCmd.AddCommand(ioKeyboardCmd)
+
+	// io keyboard subcommands
+	ioKeyboardCmd.AddCommand(ioKeyboardStatusCmd)
+	ioKeyboardCmd.AddCommand(ioKeyboardHideCmd)
 
 	// io command flags
 	ioTapCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to tap on")
@@ -217,4 +256,6 @@ func init() {
 	ioTextCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to send keys to")
 	ioKeysCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to press keys on")
 	ioSwipeCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to swipe on")
+	ioKeyboardStatusCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to check keyboard status on")
+	ioKeyboardHideCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to hide keyboard on")
 }

--- a/commands/keyboard.go
+++ b/commands/keyboard.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/mobile-next/mobilecli/devices"
+)
+
+type KeyboardRequest struct {
+	DeviceID string
+}
+
+type KeyboardHideResult struct {
+	Dismissed bool `json:"dismissed"`
+}
+
+type KeyboardStatusResult struct {
+	Visible bool `json:"visible"`
+}
+
+func keyboardControllableDevice(deviceID string) (devices.KeyboardControllable, error) {
+	device, err := FindDeviceOrAutoSelect(deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("error finding device: %w", err)
+	}
+	kb, ok := device.(devices.KeyboardControllable)
+	if !ok {
+		return nil, fmt.Errorf("keyboard commands are not supported on %s (%s)", device.ID(), device.Platform())
+	}
+	return kb, nil
+}
+
+func KeyboardHideCommand(req KeyboardRequest) *CommandResponse {
+	kb, err := keyboardControllableDevice(req.DeviceID)
+	if err != nil {
+		return NewErrorResponse(err)
+	}
+	dismissed, err := kb.HideKeyboard()
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("keyboard hide failed: %w", err))
+	}
+	return NewSuccessResponse(KeyboardHideResult{Dismissed: dismissed})
+}
+
+func KeyboardStatusCommand(req KeyboardRequest) *CommandResponse {
+	kb, err := keyboardControllableDevice(req.DeviceID)
+	if err != nil {
+		return NewErrorResponse(err)
+	}
+	visible, err := kb.IsKeyboardVisible()
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("keyboard status failed: %w", err))
+	}
+	return NewSuccessResponse(KeyboardStatusResult{Visible: visible})
+}

--- a/devices/android_keyboard.go
+++ b/devices/android_keyboard.go
@@ -1,0 +1,41 @@
+package devices
+
+import (
+	"fmt"
+	"strings"
+)
+
+// keycodeBack dismisses the on-screen keyboard when it's shown, same as a
+// physical back-button press.
+const keycodeBack = "4"
+
+// IsKeyboardVisible reports whether the on-screen keyboard is currently shown.
+// This is a system-level property read via dumpsys, so it works regardless of
+// which app is foregrounded and whether it's debuggable.
+func (d *AndroidDevice) IsKeyboardVisible() (bool, error) {
+	out, err := d.runAdbCommand("shell", "dumpsys", "input_method")
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if value, ok := strings.CutPrefix(line, "mInputShown="); ok {
+			return value == "true", nil
+		}
+	}
+	return false, fmt.Errorf("could not determine keyboard visibility: mInputShown not found in dumpsys input_method output")
+}
+
+func (d *AndroidDevice) HideKeyboard() (bool, error) {
+	visible, err := d.IsKeyboardVisible()
+	if err != nil {
+		return false, err
+	}
+	if !visible {
+		return false, nil
+	}
+	if _, err := d.runAdbCommand("shell", "input", "keyevent", keycodeBack); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/devices/android_keyboard.go
+++ b/devices/android_keyboard.go
@@ -2,12 +2,35 @@ package devices
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
 // keycodeBack dismisses the on-screen keyboard when it's shown, same as a
 // physical back-button press.
 const keycodeBack = "4"
+
+// parseInputShown extracts the mInputShown value from `dumpsys input_method`
+// output. dumpsys packs multiple "key=value" fields on a single line (e.g.
+// "mRequestedShowExplicitly=false mShowForced=false"), so mInputShown isn't
+// always alone at the start of its line — each line is split into
+// whitespace-separated fields to find it.
+func parseInputShown(dumpsysOutput string) (bool, error) {
+	for _, line := range strings.Split(dumpsysOutput, "\n") {
+		for _, field := range strings.Fields(line) {
+			value, ok := strings.CutPrefix(field, "mInputShown=")
+			if !ok {
+				continue
+			}
+			visible, err := strconv.ParseBool(value)
+			if err != nil {
+				return false, fmt.Errorf("parse mInputShown value %q: %w", value, err)
+			}
+			return visible, nil
+		}
+	}
+	return false, fmt.Errorf("could not determine keyboard visibility: mInputShown not found in dumpsys input_method output")
+}
 
 // IsKeyboardVisible reports whether the on-screen keyboard is currently shown.
 // This is a system-level property read via dumpsys, so it works regardless of
@@ -17,13 +40,7 @@ func (d *AndroidDevice) IsKeyboardVisible() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, line := range strings.Split(string(out), "\n") {
-		line = strings.TrimSpace(line)
-		if value, ok := strings.CutPrefix(line, "mInputShown="); ok {
-			return value == "true", nil
-		}
-	}
-	return false, fmt.Errorf("could not determine keyboard visibility: mInputShown not found in dumpsys input_method output")
+	return parseInputShown(string(out))
 }
 
 func (d *AndroidDevice) HideKeyboard() (bool, error) {

--- a/devices/android_keyboard_test.go
+++ b/devices/android_keyboard_test.go
@@ -1,0 +1,58 @@
+package devices
+
+import "testing"
+
+func Test_parseInputShown(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "alone on its own line, true",
+			output: "      mInputShown=true",
+			want:   true,
+		},
+		{
+			name:   "alone on its own line, false",
+			output: "      mInputShown=false",
+			want:   false,
+		},
+		{
+			name:   "packed after another field on the same line",
+			output: "      mRequestedShowExplicitly=false mInputShown=true",
+			want:   true,
+		},
+		{
+			name:   "packed before another field on the same line",
+			output: "      mInputShown=true mLastImeTargetWindow=android.os.BinderProxy@5d1074c",
+			want:   true,
+		},
+		{
+			name:    "invalid value",
+			output:  "      mInputShown=maybe",
+			wantErr: true,
+		},
+		{
+			name:    "field not present",
+			output:  "some random text\nmSystemReady=true",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseInputShown(tt.output)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseInputShown() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseInputShown() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/devices/common.go
+++ b/devices/common.go
@@ -173,6 +173,13 @@ type WebViewable interface {
 	WebViewWaitForLoadState(webviewID, state string, timeoutMs int) error
 }
 
+// KeyboardControllable is implemented by devices that can query and dismiss
+// the on-screen keyboard.
+type KeyboardControllable interface {
+	HideKeyboard() (bool, error)
+	IsKeyboardVisible() (bool, error)
+}
+
 // GetAllControllableDevices aggregates all known devices with options
 func GetAllControllableDevices(includeOffline bool) ([]ControllableDevice, error) {
 


### PR DESCRIPTION
## Summary
- Adds `mobilecli io keyboard status` and `mobilecli io keyboard hide` for Android devices.
- New `devices.KeyboardControllable` optional interface — only `AndroidDevice` implements it, so iOS (real + simulator) and remote devices return a clear "not supported" error instead of a stub/panic.
- `IsKeyboardVisible()` / `HideKeyboard()` shell out directly via `adb shell dumpsys input_method` (`mInputShown=`) and `adb shell input keyevent 4` (BACK) — no on-device agent, no app-debuggable requirement. `HideKeyboard` only sends BACK when the keyboard is actually visible, so it never fires a stray back-navigation.