### PR TITLE
feat: dump ui via persistent devicekit server on android

### DIFF
--- a/devices/android.go
+++ b/devices/android.go
@@ -1557,7 +1557,20 @@ func collectDeviceKitElements(nodes []deviceKitNode) []types.ScreenElement {
 	return elements
 }
 
+// getDeviceKitNodes returns the UI hierarchy, preferring the persistent
+// DeviceKitServer (fast: no process fork per call) and falling back to the
+// one-shot ViewTreeDump instrumentation when the server isn't available.
 func (d *AndroidDevice) getDeviceKitNodes() ([]deviceKitNode, error) {
+	if nodes, err := d.getDeviceKitServerNodes(); err == nil {
+		return nodes, nil
+	} else {
+		utils.Verbose("devicekit server dump unavailable, falling back to one-shot instrument: %v", err)
+	}
+
+	return d.getDeviceKitNodesOneShot()
+}
+
+func (d *AndroidDevice) getDeviceKitNodesOneShot() ([]deviceKitNode, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/devices/android_uidump_server.go
+++ b/devices/android_uidump_server.go
@@ -1,0 +1,87 @@
+package devices
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mobile-next/mobilecli/utils"
+)
+
+// deviceKitServerTarget is the localabstract socket DeviceKitServer binds once
+// launched. Reusing one persistent instrumentation avoids paying process-fork
+// and UiAutomation-connect cost on every dump ui call.
+const deviceKitServerTarget = "localabstract:devicekit"
+
+// deviceKitServerWaitUntilIdleMs matches the idle wait used by the legacy
+// one-shot ViewTreeDump instrumentation, so dumps settle the same way.
+const deviceKitServerWaitUntilIdleMs = 2000
+
+// ensureDeviceKitServerReady makes sure the persistent DeviceKitServer
+// instrumentation is running and forwarded, reusing an existing forward when
+// possible. It's launched detached (nohup + &) on the device shell so it
+// outlives this CLI invocation and keeps serving fast dumps for subsequent
+// mobilecli calls.
+func (d *AndroidDevice) ensureDeviceKitServerReady() (int, error) {
+	if port := d.findForward(deviceKitServerTarget); port != 0 && isAgentReady(port) {
+		return port, nil
+	}
+
+	if err := d.EnsureDeviceKitInstalled(); err != nil {
+		return 0, fmt.Errorf("ensure devicekit installed: %w", err)
+	}
+
+	// -w keeps `am` blocked (and its UiAutomationConnection alive) for as long as
+	// DeviceKitServer runs; nohup+& detaches it from this adb shell session so it
+	// survives after this command returns.
+	launchCmd := "nohup am instrument -w com.mobilenext.devicekit/.DeviceKitServer >/dev/null 2>&1 &"
+	if out, err := d.runAdbCommand("shell", launchCmd); err != nil {
+		return 0, fmt.Errorf("launch devicekit server: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	out, err := d.runAdbCommand("forward", "tcp:0", deviceKitServerTarget)
+	if err != nil {
+		return 0, fmt.Errorf("adb forward: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("unexpected adb forward output %q: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !isAgentReady(port) {
+		if time.Now().After(deadline) {
+			return 0, fmt.Errorf("devicekit server did not start within 5s on port %d", port)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return port, nil
+}
+
+// getDeviceKitServerNodes fetches the UI hierarchy from the persistent
+// DeviceKitServer. This is the fast path for DumpSourceRaw/DumpSource; callers
+// fall back to the one-shot instrumentation when it's unavailable.
+func (d *AndroidDevice) getDeviceKitServerNodes() ([]deviceKitNode, error) {
+	startTime := time.Now()
+
+	port, err := d.ensureDeviceKitServerReady()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := agentRequest(port, "device.dump.ui", map[string]any{"waitUntilIdle": deviceKitServerWaitUntilIdleMs})
+	if err != nil {
+		return nil, fmt.Errorf("devicekit server dump.ui: %w", err)
+	}
+
+	var hierarchy deviceKitHierarchy
+	if err := json.Unmarshal(raw, &hierarchy); err != nil {
+		return nil, fmt.Errorf("parse devicekit server response: %w", err)
+	}
+
+	utils.Verbose("getDeviceKitServerNodes took %s", time.Since(startTime))
+	return hierarchy.Hierarchy, nil
+}

--- a/devices/android_uidump_server.go
+++ b/devices/android_uidump_server.go
@@ -53,12 +53,22 @@ func (d *AndroidDevice) ensureDeviceKitServerReady() (int, error) {
 	deadline := time.Now().Add(5 * time.Second)
 	for !isAgentReady(port) {
 		if time.Now().After(deadline) {
+			d.removeForward(port)
 			return 0, fmt.Errorf("devicekit server did not start within 5s on port %d", port)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
 	return port, nil
+}
+
+// removeForward tears down a host TCP forward created by this device, best
+// effort — used to avoid leaking a forward when the server it points at never
+// became ready.
+func (d *AndroidDevice) removeForward(port int) {
+	if _, err := d.runAdbCommand("forward", "--remove", fmt.Sprintf("tcp:%d", port)); err != nil {
+		utils.Verbose("failed to remove stale forward on port %d: %v", port, err)
+	}
 }
 
 // getDeviceKitServerNodes fetches the UI hierarchy from the persistent
@@ -80,6 +90,9 @@ func (d *AndroidDevice) getDeviceKitServerNodes() ([]deviceKitNode, error) {
 	var hierarchy deviceKitHierarchy
 	if err := json.Unmarshal(raw, &hierarchy); err != nil {
 		return nil, fmt.Errorf("parse devicekit server response: %w", err)
+	}
+	if len(hierarchy.Hierarchy) == 0 {
+		return nil, fmt.Errorf("no hierarchy found in devicekit server dump")
 	}
 
 	utils.Verbose("getDeviceKitServerNodes took %s", time.Since(startTime))


### PR DESCRIPTION
## Summary
- `dump ui --format raw` on Android currently dumps the UI tree by relaunching a one-shot `am instrument ... ViewTreeDump` process every call (~0.9–3.2s each), or falling back to `uiautomator dump`.
- `devicekit-android` already ships `DeviceKitServer`, an `Instrumentation` that connects `UiAutomation` once and serves `device.dump.ui` over a persistent JSON-RPC socket, using the same `UiTreeSerializer` as `ViewTreeDump`.
- This wires `mobilecli` to launch `DeviceKitServer` once (detached via `nohup ... &` so it outlives the CLI invocation), reuse the existing `adb forward` / agent-ready helpers to reach it, and fall back to the old one-shot instrumentation path when the server isn't reachable.

## Performance
- Cold call (server not yet running): pays a one-time launch cost.
- Warm calls (server already running, fresh CLI process each time): ~5–40ms per dump vs ~0.9–3.2s before — roughly 25–80x faster for the dump itself.
- Output schema verified identical to the current raw-format output (same 12 node fields, same top-level `hierarchy` key, same node count on a like-for-like dump) since both paths share the same serializer.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet` / `golangci-lint run` — no new findings introduced (pre-existing warnings in `ios.go`/`adb_test.go` untouched)
- [x] Manual: `mobilecli dump ui --format raw` and `mobilecli dump ui` against a running Android emulator, before and after, comparing output shape/content
- [x] Manual: verified fallback still works when the persistent server isn't available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent Android UI hierarchy retrieval for faster, reusable device inspections.
  * Automatically reuses an available connection or starts a new one when needed.
  * Added clear handling for connection, launch, forwarding, and readiness failures.

* **Bug Fixes**
  * Added a fallback to the existing one-time inspection method when the persistent service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->