### PR TITLE
feat(screencapture): default FPS to 30 instead of leaving it unset

### DIFF
--- a/commands/screencapture.go
+++ b/commands/screencapture.go
@@ -5,4 +5,5 @@ type ScreenCaptureRequest struct {
 	Format   string  `json:"format"`
 	Quality  int     `json:"quality,omitempty"`
 	Scale    float64 `json:"scale,omitempty"`
+	FPS      int     `json:"fps,omitempty"`
 }

--- a/server/screencapture_fps_test.go
+++ b/server/screencapture_fps_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mobile-next/mobilecli/commands"
+)
+
+// Both screen-capture entry points validate fps before any device work, so a
+// negative value can never reach the device capture launch. There's no device
+// mocking in this package, so success cases (omitted/zero/positive) are
+// asserted by confirming they get PAST fps validation — they fail later with
+// "error finding device" in this device-less test environment, not with the
+// fps error. Only negative should fail with the fps error specifically.
+func TestScreenCaptureSessionFPSValidation(t *testing.T) {
+	cases := []struct {
+		name       string
+		fps        int
+		wantFPSErr bool
+	}{
+		{"omitted fps", 0, false},
+		{"explicit zero fps (same as omitted)", 0, false},
+		{"positive fps", 24, false},
+		{"negative fps", -1, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			params, _ := json.Marshal(commands.ScreenCaptureRequest{Format: "avc", FPS: c.fps})
+			_, err := handleScreenCaptureSession(params)
+			if err == nil {
+				t.Fatalf("expected an error (no device in test env), got nil")
+			}
+			isFPSErr := strings.Contains(err.Error(), "fps must not be negative")
+			if isFPSErr != c.wantFPSErr {
+				t.Fatalf("fps=%d: got err=%v, wantFPSErr=%v", c.fps, err, c.wantFPSErr)
+			}
+		})
+	}
+}
+
+func TestScreenCaptureFPSValidation(t *testing.T) {
+	cases := []struct {
+		name       string
+		fps        int
+		wantFPSErr bool
+	}{
+		{"omitted fps", 0, false},
+		{"explicit zero fps (same as omitted)", 0, false},
+		{"positive fps", 24, false},
+		{"negative fps", -1, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			params, _ := json.Marshal(commands.ScreenCaptureRequest{Format: "avc", FPS: c.fps})
+			err := handleScreenCapture(nil, httptest.NewRecorder(), params)
+			if err == nil {
+				t.Fatalf("expected an error (no device in test env), got nil")
+			}
+			isFPSErr := strings.Contains(err.Error(), "fps must not be negative")
+			if isFPSErr != c.wantFPSErr {
+				t.Fatalf("fps=%d: got err=%v, wantFPSErr=%v", c.fps, err, c.wantFPSErr)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1284,6 +1284,12 @@ func handleScreenCaptureSession(params json.RawMessage) (any, error) {
 		return nil, fmt.Errorf("format must be 'mjpeg' or 'avc' for screen capture")
 	}
 
+	// validate fps before any device work — 0 means omitted (defaulted below),
+	// negative is never valid
+	if screenCaptureParams.FPS < 0 {
+		return nil, fmt.Errorf("fps must not be negative")
+	}
+
 	// validate device exists (early error detection)
 	targetDevice, err := commands.FindDeviceOrAutoSelect(screenCaptureParams.DeviceID)
 	if err != nil {
@@ -1523,12 +1529,6 @@ func handleScreenCapture(r *http.Request, w http.ResponseWriter, params json.Raw
 		return fmt.Errorf("invalid parameters: %w", err)
 	}
 
-	// Find the target device
-	targetDevice, err := commands.FindDeviceOrAutoSelect(screenCaptureParams.DeviceID)
-	if err != nil {
-		return fmt.Errorf("error finding device: %w", err)
-	}
-
 	// Set default format if not provided
 	if screenCaptureParams.Format == "" {
 		screenCaptureParams.Format = "mjpeg"
@@ -1537,6 +1537,18 @@ func handleScreenCapture(r *http.Request, w http.ResponseWriter, params json.Raw
 	// Validate format
 	if screenCaptureParams.Format != "mjpeg" && screenCaptureParams.Format != "avc" {
 		return fmt.Errorf("format must be 'mjpeg' or 'avc' for screen capture")
+	}
+
+	// validate fps before any device work — 0 means omitted (defaulted below),
+	// negative is never valid
+	if screenCaptureParams.FPS < 0 {
+		return fmt.Errorf("fps must not be negative")
+	}
+
+	// Find the target device
+	targetDevice, err := commands.FindDeviceOrAutoSelect(screenCaptureParams.DeviceID)
+	if err != nil {
+		return fmt.Errorf("error finding device: %w", err)
 	}
 
 	// avc format is supported on Android and iOS real devices (not simulators)

--- a/server/server.go
+++ b/server/server.go
@@ -60,6 +60,7 @@ type StreamSession struct {
 	Format    string // "mjpeg" or "avc"
 	Quality   int
 	Scale     float64
+	FPS       int
 	CreatedAt time.Time
 	ExpiresAt time.Time // CreatedAt + 1 minute
 	InUse     bool      // prevents duplicate connections
@@ -1312,6 +1313,11 @@ func handleScreenCaptureSession(params json.RawMessage) (any, error) {
 		scale = devices.DefaultScale
 	}
 
+	fps := screenCaptureParams.FPS
+	if fps == 0 {
+		fps = devices.DefaultFramerate
+	}
+
 	// generate session ID
 	sessionID := uuid.New().String()
 
@@ -1328,6 +1334,7 @@ func handleScreenCaptureSession(params json.RawMessage) (any, error) {
 		Format:    screenCaptureParams.Format,
 		Quality:   quality,
 		Scale:     scale,
+		FPS:       fps,
 		CreatedAt: time.Now(),
 		ExpiresAt: time.Now().Add(1 * time.Minute),
 		InUse:     false,
@@ -1481,6 +1488,7 @@ func handleStream(w http.ResponseWriter, r *http.Request) {
 		Format:     session.Format,
 		Quality:    session.Quality,
 		Scale:      session.Scale,
+		FPS:        session.FPS,
 		OnProgress: progressCallback,
 		OnData: func(data []byte) bool {
 			_, writeErr := w.Write(data)
@@ -1549,6 +1557,11 @@ func handleScreenCapture(r *http.Request, w http.ResponseWriter, params json.Raw
 		scale = devices.DefaultScale
 	}
 
+	fps := screenCaptureParams.FPS
+	if fps == 0 {
+		fps = devices.DefaultFramerate
+	}
+
 	// Set headers for streaming response based on format
 	if screenCaptureParams.Format == "mjpeg" {
 		w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary=BoundaryString")
@@ -1592,6 +1605,7 @@ func handleScreenCapture(r *http.Request, w http.ResponseWriter, params json.Raw
 		Format:     screenCaptureParams.Format,
 		Quality:    quality,
 		Scale:      scale,
+		FPS:        fps,
 		OnProgress: progressCallback,
 		OnData: func(data []byte) bool {
 			_, writeErr := w.Write(data)


### PR DESCRIPTION
Neither streaming path defaulted FPS the way quality/scale already do — it stayed at 0 and got passed through as `--fps 0` to the device capture launch. Defaults to `devices.DefaultFramerate` (30) when unset, matching the existing quality/scale pattern; also exposes `fps` as an optional request field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional frame rate setting for screen-capture requests.
  * Screen-capture sessions now use the specified FPS, or a default frame rate when none is provided.
  * Applied frame-rate settings consistently across session-based and direct screen capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->