### PR TITLE
fix(android): pass --scale with 4-decimal precision

### DIFF
--- a/devices/android.go
+++ b/devices/android.go
@@ -1155,7 +1155,7 @@ func (d *AndroidDevice) StartScreenCapture(config ScreenCaptureConfig) error {
 	}
 
 	utils.Verbose("Starting %s with app path: %s", serverClass, appPath)
-	cmdArgs := append([]string{"-s", d.getAdbIdentifier()}, "exec-out", fmt.Sprintf("CLASSPATH=%s", appPath), "app_process", "/system/bin", serverClass, "--quality", fmt.Sprintf("%d", config.Quality), "--scale", fmt.Sprintf("%.2f", config.Scale), "--fps", fmt.Sprintf("%d", config.FPS))
+	cmdArgs := append([]string{"-s", d.getAdbIdentifier()}, "exec-out", fmt.Sprintf("CLASSPATH=%s", appPath), "app_process", "/system/bin", serverClass, "--quality", fmt.Sprintf("%d", config.Quality), "--scale", fmt.Sprintf("%.4f", config.Scale), "--fps", fmt.Sprintf("%d", config.FPS))
 
 	// bitrate only applies to AvcServer
 	if config.Format == "avc" && config.Bitrate > 0 {


### PR DESCRIPTION
%.2f quantized the requested capture scale before it reached devicekit — 0.4988 became "0.50", so fine-grained scale adjustments were silently a no-op (found while diagnosing the odd-dimension capture failure, mobile-next/devicekit-android#42). %.4f keeps the requested value.

- [x] go build passes (go vet has pre-existing unrelated failures in ios.go on main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android screen capture scale precision by preserving up to four decimal places in the device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->