### PR TITLE
feat: optional duration for swipe gestures

### DIFF
--- a/cli/io.go
+++ b/cli/io.go
@@ -54,6 +54,7 @@ var ioTapCmd = &cobra.Command{
 }
 
 var longPressDuration int
+var swipeDuration int
 
 var ioLongPressCmd = &cobra.Command{
 	Use:   "longpress [x,y]",
@@ -187,6 +188,7 @@ var ioSwipeCmd = &cobra.Command{
 			Y1:       y1,
 			X2:       x2,
 			Y2:       y2,
+			Duration: swipeDuration,
 		}
 
 		response := commands.SwipeCommand(req)
@@ -213,6 +215,7 @@ func init() {
 	ioTapCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to tap on")
 	ioLongPressCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to long press on")
 	ioLongPressCmd.Flags().IntVar(&longPressDuration, "duration", 500, "duration of the long press in milliseconds")
+	ioSwipeCmd.Flags().IntVar(&swipeDuration, "duration", 0, "duration of the swipe in milliseconds (0 uses the platform default)")
 	ioButtonCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to press button on")
 	ioTextCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to send keys to")
 	ioKeysCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to press keys on")

--- a/commands/input.go
+++ b/commands/input.go
@@ -48,6 +48,7 @@ type SwipeRequest struct {
 	Y1       int    `json:"y1"`
 	X2       int    `json:"x2"`
 	Y2       int    `json:"y2"`
+	Duration int    `json:"duration"`
 }
 
 // TapCommand performs a tap operation on the specified device
@@ -219,7 +220,7 @@ func SwipeCommand(req SwipeRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
 	}
 
-	err = targetDevice.Swipe(req.X1, req.Y1, req.X2, req.Y2)
+	err = targetDevice.Swipe(req.X1, req.Y1, req.X2, req.Y2, req.Duration)
 	if err != nil {
 		return NewErrorResponse(fmt.Errorf("failed to swipe on device %s: %v", targetDevice.ID(), err))
 	}

--- a/devices/android.go
+++ b/devices/android.go
@@ -414,9 +414,16 @@ func (d *AndroidDevice) LongPress(x, y, duration int) error {
 	return nil
 }
 
-// Swipe simulates a swipe gesture from (x1, y1) to (x2, y2) on the Android device with 1000ms duration.
-func (d *AndroidDevice) Swipe(x1, y1, x2, y2 int) error {
-	_, err := d.runAdbCommand("shell", "input", "swipe", fmt.Sprintf("%d", x1), fmt.Sprintf("%d", y1), fmt.Sprintf("%d", x2), fmt.Sprintf("%d", y2), "1000")
+const defaultSwipeDurationMs = 1000
+
+// Swipe simulates a swipe gesture from (x1, y1) to (x2, y2) on the Android device.
+// duration is in milliseconds; zero or less keeps the 1000ms this has always used.
+func (d *AndroidDevice) Swipe(x1, y1, x2, y2, duration int) error {
+	if duration <= 0 {
+		duration = defaultSwipeDurationMs
+	}
+
+	_, err := d.runAdbCommand("shell", "input", "swipe", fmt.Sprintf("%d", x1), fmt.Sprintf("%d", y1), fmt.Sprintf("%d", x2), fmt.Sprintf("%d", y2), fmt.Sprintf("%d", duration))
 	if err != nil {
 		return err
 	}

--- a/devices/common.go
+++ b/devices/common.go
@@ -126,7 +126,7 @@ type ControllableDevice interface {
 	Shutdown() error // shutdown simulator/emulator
 	Tap(x, y int) error
 	LongPress(x, y, duration int) error
-	Swipe(x1, y1, x2, y2 int) error
+	Swipe(x1, y1, x2, y2, duration int) error
 	Gesture(actions []devicekit.TapAction) error
 	StartAgent(config StartAgentConfig) error
 	SendKeys(text string) error

--- a/devices/devicekit/swipe.go
+++ b/devices/devicekit/swipe.go
@@ -1,11 +1,16 @@
 package devicekit
 
-func (c *DeviceKitClient) Swipe(x1, y1, x2, y2 int) error {
-	params := map[string]int{
+func (c *DeviceKitClient) Swipe(x1, y1, x2, y2, duration int) error {
+	params := map[string]any{
 		"x1": x1,
 		"y1": y1,
 		"x2": x2,
 		"y2": y2,
+	}
+
+	// Left out when unset so the agent keeps applying its own default.
+	if duration > 0 {
+		params["duration"] = float64(duration) / 1000.0 // convert ms to seconds
 	}
 
 	_, err := c.CallRPC("device.io.swipe", params)

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -219,8 +219,8 @@ func (d IOSDevice) LongPress(x, y, duration int) error {
 	return d.deviceKitClient.LongPress(x, y, duration)
 }
 
-func (d IOSDevice) Swipe(x1, y1, x2, y2 int) error {
-	return d.deviceKitClient.Swipe(x1, y1, x2, y2)
+func (d IOSDevice) Swipe(x1, y1, x2, y2, duration int) error {
+	return d.deviceKitClient.Swipe(x1, y1, x2, y2, duration)
 }
 
 func (d IOSDevice) Gesture(actions []devicekit.TapAction) error {

--- a/devices/remote.go
+++ b/devices/remote.go
@@ -123,8 +123,13 @@ func (r *RemoteDevice) LongPress(x, y, duration int) error {
 	return r.fireRPC("device.io.longpress", params{"x": x, "y": y, "duration": duration})
 }
 
-func (r *RemoteDevice) Swipe(x1, y1, x2, y2 int) error {
-	return r.fireRPC("device.io.swipe", params{"x1": x1, "y1": y1, "x2": x2, "y2": y2})
+func (r *RemoteDevice) Swipe(x1, y1, x2, y2, duration int) error {
+	p := params{"x1": x1, "y1": y1, "x2": x2, "y2": y2}
+	if duration > 0 {
+		p["duration"] = duration
+	}
+
+	return r.fireRPC("device.io.swipe", p)
 }
 
 func (r *RemoteDevice) Gesture(actions []devicekit.TapAction) error {

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -582,8 +582,8 @@ func (s SimulatorDevice) LongPress(x, y, duration int) error {
 	return s.deviceKitClient.LongPress(x, y, duration)
 }
 
-func (s SimulatorDevice) Swipe(x1, y1, x2, y2 int) error {
-	return s.deviceKitClient.Swipe(x1, y1, x2, y2)
+func (s SimulatorDevice) Swipe(x1, y1, x2, y2, duration int) error {
+	return s.deviceKitClient.Swipe(x1, y1, x2, y2, duration)
 }
 
 func (s SimulatorDevice) Gesture(actions []devicekit.TapAction) error {

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -442,6 +442,14 @@
           "schema": {
             "type": "integer"
           }
+        },
+        {
+          "name": "duration",
+          "description": "Duration of the swipe in milliseconds, omitted applies the platform default",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
         }
       ],
       "result": {

--- a/docs/openrpc.md
+++ b/docs/openrpc.md
@@ -908,6 +908,7 @@ Performs a swipe gesture from one coordinate to another on the device screen
 | `y1` | `integer` | ✓ | Starting Y coordinate |
 | `x2` | `integer` | ✓ | Ending X coordinate |
 | `y2` | `integer` | ✓ | Ending Y coordinate |
+| `duration` | `integer` |  | Duration of the swipe in milliseconds, omitted applies the platform default |
 
 #### Response
 
@@ -926,7 +927,8 @@ Operation result
     "x1": 0,
     "y1": 0,
     "x2": 0,
-    "y2": 0
+    "y2": 0,
+    "duration": 0
   },
   "id": 1
 }

--- a/server/server.go
+++ b/server/server.go
@@ -448,6 +448,7 @@ type IoSwipeParams struct {
 	Y1       int    `json:"y1"`
 	X2       int    `json:"x2"`
 	Y2       int    `json:"y2"`
+	Duration int    `json:"duration"`
 }
 
 func handleIoTap(params json.RawMessage) (any, error) {
@@ -538,6 +539,7 @@ func handleIoSwipe(params json.RawMessage) (any, error) {
 		Y1:       ioSwipeParams.Y1,
 		X2:       ioSwipeParams.X2,
 		Y2:       ioSwipeParams.Y2,
+		Duration: ioSwipeParams.Duration,
 	}
 
 	response := commands.SwipeCommand(req)


### PR DESCRIPTION
## Summary
CLI side of the swipe duration support merged in mobile-next/devicekit-ios#62. Adds an optional `--duration` in milliseconds to `io swipe`.

- **Android**: passed to `adb shell input swipe`, defaulting to the 1000ms it has always used.
- **iOS**: optional, and left out of the RPC when not given so the agent applies its own default. Takes effect with devicekit-ios 0.0.24.

Verified on an iPhone 11 (iOS 26.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable swipe duration through the CLI using the `--duration` option.
  * Added support for specifying swipe duration in API requests.
  * Duration is measured in milliseconds; non-positive values use the platform’s default behavior.
  * Swipe duration is now supported consistently across Android, iOS, simulator, and remote devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->