### PR TITLE
feat: clipboard get and set commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ mobilecli io button --device <device-id> POWER
 
 # Send text
 mobilecli io text --device <device-id> 'hello world'
+
+# Read device clipboard
+mobilecli io clipboard get --device <device-id>
+
+# Write device clipboard
+mobilecli io clipboard set --device <device-id> 'hello world'
 ```
 
 ### Supported Hardware Buttons

--- a/cli/clipboard.go
+++ b/cli/clipboard.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mobile-next/mobilecli/commands"
+	"github.com/spf13/cobra"
+)
+
+var clipboardCmd = &cobra.Command{
+	Use:   "clipboard",
+	Short: "Clipboard commands",
+	Long:  `Commands for reading and writing the device clipboard.`,
+}
+
+var clipboardGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Read the clipboard of a device",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		response := commands.ClipboardGetCommand(commands.ClipboardGetRequest{
+			DeviceID: deviceId,
+		})
+
+		printJson(response)
+		if response.Status == "error" {
+			return fmt.Errorf("%s", response.Error)
+		}
+		return nil
+	},
+}
+
+var clipboardSetCmd = &cobra.Command{
+	Use:   "set [text]",
+	Short: "Replace the clipboard of a device",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		response := commands.ClipboardSetCommand(commands.ClipboardSetRequest{
+			DeviceID: deviceId,
+			Text:     args[0],
+		})
+
+		printJson(response)
+		if response.Status == "error" {
+			return fmt.Errorf("%s", response.Error)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(clipboardCmd)
+	clipboardCmd.AddCommand(clipboardGetCmd)
+	clipboardCmd.AddCommand(clipboardSetCmd)
+
+	clipboardGetCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to read the clipboard from")
+	clipboardSetCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to write the clipboard on")
+}

--- a/cli/clipboard.go
+++ b/cli/clipboard.go
@@ -48,7 +48,7 @@ var clipboardSetCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(clipboardCmd)
+	ioCmd.AddCommand(clipboardCmd)
 	clipboardCmd.AddCommand(clipboardGetCmd)
 	clipboardCmd.AddCommand(clipboardSetCmd)
 

--- a/cli/io.go
+++ b/cli/io.go
@@ -12,7 +12,7 @@ import (
 var ioCmd = &cobra.Command{
 	Use:   "io",
 	Short: "Input/output operations with devices",
-	Long:  `Perform input/output operations like tapping, pressing buttons, and sending text to devices.`,
+	Long:  `Perform input/output operations like tapping, pressing buttons, sending text, and reading or writing the device clipboard.`,
 }
 
 var ioTapCmd = &cobra.Command{

--- a/cli/root.go
+++ b/cli/root.go
@@ -91,6 +91,12 @@ INPUT/OUTPUT:
   # Send text input
   mobilecli io text --device <device-id> "Hello World"
 
+  # Read device clipboard
+  mobilecli io clipboard get --device <device-id>
+
+  # Write device clipboard
+  mobilecli io clipboard set --device <device-id> "Hello World"
+
 WEBVIEW:
   # List embedded webviews in the foreground app
   mobilecli webview list --device <device-id>

--- a/commands/clipboard.go
+++ b/commands/clipboard.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/mobile-next/mobilecli/devices"
+)
+
+type ClipboardGetRequest struct {
+	DeviceID string `json:"deviceId"`
+}
+
+type ClipboardSetRequest struct {
+	DeviceID string `json:"deviceId"`
+	Text     string `json:"text"`
+}
+
+type ClipboardResult struct {
+	Text string `json:"text"`
+}
+
+func ClipboardGetCommand(req ClipboardGetRequest) *CommandResponse {
+	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
+	}
+
+	err = targetDevice.StartAgent(devices.StartAgentConfig{
+		Hook: GetShutdownHook(),
+	})
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+	}
+
+	text, err := targetDevice.GetClipboard()
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("failed to read clipboard on device %s: %v", targetDevice.ID(), err))
+	}
+
+	return NewSuccessResponse(ClipboardResult{Text: text})
+}
+
+func ClipboardSetCommand(req ClipboardSetRequest) *CommandResponse {
+	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
+	}
+
+	err = targetDevice.StartAgent(devices.StartAgentConfig{
+		Hook: GetShutdownHook(),
+	})
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+	}
+
+	err = targetDevice.SetClipboard(req.Text)
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("failed to write clipboard on device %s: %v", targetDevice.ID(), err))
+	}
+
+	return NewSuccessResponse(MessageResult{
+		Message: fmt.Sprintf("Clipboard set on device %s", targetDevice.ID()),
+	})
+}

--- a/devices/android.go
+++ b/devices/android.go
@@ -424,6 +424,43 @@ func (d *AndroidDevice) Swipe(x1, y1, x2, y2 int) error {
 	return nil
 }
 
+const devicekitClipboardClass = "com.mobilenext.devicekit.Clipboard"
+
+func (d *AndroidDevice) clipboardCommand(args ...string) (string, error) {
+	appPath, err := d.GetAppPath("com.mobilenext.devicekit")
+	if err != nil || appPath == "" {
+		return "", fmt.Errorf("DeviceKit is not installed on device %s, it is required for clipboard access", d.ID())
+	}
+
+	cmdArgs := append([]string{"exec-out", fmt.Sprintf("CLASSPATH=%s", appPath), "app_process", "/system/bin", devicekitClipboardClass}, args...)
+	out, err := d.runAdbCommand(cmdArgs...)
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}
+
+func (d *AndroidDevice) GetClipboard() (string, error) {
+	out, err := d.clipboardCommand("get")
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(out, "\n"), nil
+}
+
+func (d *AndroidDevice) SetClipboard(text string) error {
+	if text == "" {
+		_, err := d.clipboardCommand("clear")
+		return err
+	}
+
+	// base64 keeps spaces, emoji and other UTF-8 intact across the shell.
+	_, err := d.clipboardCommand("set", "--base64", base64.StdEncoding.EncodeToString([]byte(text)))
+	return err
+}
+
 // Gesture performs a sequence of touch actions on the Android device
 func (d *AndroidDevice) Gesture(actions []devicekit.TapAction) error {
 

--- a/devices/common.go
+++ b/devices/common.go
@@ -130,6 +130,8 @@ type ControllableDevice interface {
 	Gesture(actions []devicekit.TapAction) error
 	StartAgent(config StartAgentConfig) error
 	SendKeys(text string) error
+	GetClipboard() (string, error)
+	SetClipboard(text string) error
 	PressKeys(combos []KeyCombo) error
 	PressButton(key string) error
 	LaunchApp(bundleID string, opts LaunchOptions) error

--- a/devices/devicekit/clipboard.go
+++ b/devices/devicekit/clipboard.go
@@ -1,0 +1,33 @@
+package devicekit
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type clipboardText struct {
+	Text string `json:"text"`
+}
+
+func (c *DeviceKitClient) GetClipboard() (string, error) {
+	result, err := c.CallRPC("device.clipboard.get", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get clipboard: %w", err)
+	}
+
+	var clipboard clipboardText
+	if err := json.Unmarshal(result, &clipboard); err != nil {
+		return "", fmt.Errorf("failed to parse clipboard: %w", err)
+	}
+
+	return clipboard.Text, nil
+}
+
+func (c *DeviceKitClient) SetClipboard(text string) error {
+	_, err := c.CallRPC("device.clipboard.set", map[string]any{"text": text})
+	if err != nil {
+		return fmt.Errorf("failed to set clipboard: %w", err)
+	}
+
+	return nil
+}

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -223,6 +223,14 @@ func (d IOSDevice) Swipe(x1, y1, x2, y2 int) error {
 	return d.deviceKitClient.Swipe(x1, y1, x2, y2)
 }
 
+func (d IOSDevice) GetClipboard() (string, error) {
+	return d.deviceKitClient.GetClipboard()
+}
+
+func (d IOSDevice) SetClipboard(text string) error {
+	return d.deviceKitClient.SetClipboard(text)
+}
+
 func (d IOSDevice) Gesture(actions []devicekit.TapAction) error {
 	return d.deviceKitClient.Gesture(actions)
 }

--- a/devices/remote.go
+++ b/devices/remote.go
@@ -127,6 +127,21 @@ func (r *RemoteDevice) Swipe(x1, y1, x2, y2 int) error {
 	return r.fireRPC("device.io.swipe", params{"x1": x1, "y1": y1, "x2": x2, "y2": y2})
 }
 
+func (r *RemoteDevice) GetClipboard() (string, error) {
+	resp, err := rpcCall[struct {
+		Text string `json:"text"`
+	}](r, "device.clipboard.get", params{})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Text, nil
+}
+
+func (r *RemoteDevice) SetClipboard(text string) error {
+	return r.fireRPC("device.clipboard.set", params{"text": text})
+}
+
 func (r *RemoteDevice) Gesture(actions []devicekit.TapAction) error {
 	return r.fireRPC("device.io.gesture", params{"actions": actions})
 }

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -586,6 +586,14 @@ func (s SimulatorDevice) Swipe(x1, y1, x2, y2 int) error {
 	return s.deviceKitClient.Swipe(x1, y1, x2, y2)
 }
 
+func (s SimulatorDevice) GetClipboard() (string, error) {
+	return s.deviceKitClient.GetClipboard()
+}
+
+func (s SimulatorDevice) SetClipboard(text string) error {
+	return s.deviceKitClient.SetClipboard(text)
+}
+
 func (s SimulatorDevice) Gesture(actions []devicekit.TapAction) error {
 	return s.deviceKitClient.Gesture(actions)
 }

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -272,6 +272,64 @@
       }
     },
     {
+      "name": "device.clipboard.get",
+      "summary": "Read clipboard",
+      "description": "Reads the text currently on the device clipboard",
+      "params": [
+        {
+          "name": "deviceId",
+          "description": "ID of the target device",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "clipboard",
+        "description": "Clipboard contents",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Text on the clipboard, empty when it holds no text"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "device.clipboard.set",
+      "summary": "Write clipboard",
+      "description": "Replaces the text on the device clipboard, an empty string clears it",
+      "params": [
+        {
+          "name": "deviceId",
+          "description": "ID of the target device",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "text",
+          "description": "Text to place on the clipboard",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "success",
+        "description": "Operation result",
+        "schema": {
+          "$ref": "#/components/schemas/SuccessResult"
+        }
+      }
+    },
+    {
       "name": "device.io.keys",
       "summary": "Press keyboard keys",
       "description": "Presses one or more key combinations on the device, in order. Each combo is a key with optional modifiers joined by '+', e.g. \"cmd+a\", \"ctrl+shift+z\", \"backspace\". Modifiers: cmd/command/meta, ctrl/control, alt/opt/option, shift, fn. Keys are case-insensitive.",

--- a/docs/openrpc.md
+++ b/docs/openrpc.md
@@ -15,6 +15,8 @@ JSON-RPC API for mobile device automation and control
 - [device.apps.terminate](#deviceappsterminate)
 - [device.apps.uninstall](#deviceappsuninstall)
 - [device.boot](#deviceboot)
+- [device.clipboard.get](#deviceclipboardget)
+- [device.clipboard.set](#deviceclipboardset)
 - [device.crashes.get](#devicecrashesget)
 - [device.crashes.list](#devicecrasheslist)
 - [device.dump.ui](#devicedumpui)
@@ -363,6 +365,72 @@ Boot operation result
   "method": "device.boot",
   "params": {
     "deviceId": "string"
+  },
+  "id": 1
+}
+```
+
+
+### device.clipboard.get
+
+**Read clipboard**
+
+Reads the text currently on the device clipboard
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `deviceId` | `string` | ✓ | ID of the target device |
+
+#### Response
+
+**Type:** `object`
+
+Clipboard contents
+
+#### Example Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "device.clipboard.get",
+  "params": {
+    "deviceId": "string"
+  },
+  "id": 1
+}
+```
+
+
+### device.clipboard.set
+
+**Write clipboard**
+
+Replaces the text on the device clipboard, an empty string clears it
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `deviceId` | `string` | ✓ | ID of the target device |
+| `text` | `string` | ✓ | Text to place on the clipboard |
+
+#### Response
+
+**Type:** [`SuccessResult`](#successresult)
+
+Operation result
+
+#### Example Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "device.clipboard.set",
+  "params": {
+    "deviceId": "string",
+    "text": "string"
   },
   "id": 1
 }

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -23,6 +23,8 @@ func GetMethodRegistry() map[string]HandlerFunc {
 		"device.io.keys":                        handleIoKeys,
 		"device.io.button":                      handleIoButton,
 		"device.io.swipe":                       handleIoSwipe,
+		"device.clipboard.get":                  handleClipboardGet,
+		"device.clipboard.set":                  handleClipboardSet,
 		"device.io.gesture":                     handleIoGesture,
 		"device.url":                            handleURL,
 		"device.info":                           handleDeviceInfo,

--- a/server/server.go
+++ b/server/server.go
@@ -553,8 +553,8 @@ type ClipboardGetParams struct {
 }
 
 type ClipboardSetParams struct {
-	DeviceID string `json:"deviceId"`
-	Text     string `json:"text"`
+	DeviceID string  `json:"deviceId"`
+	Text     *string `json:"text"`
 }
 
 func handleClipboardGet(params json.RawMessage) (any, error) {
@@ -585,9 +585,13 @@ func handleClipboardSet(params json.RawMessage) (any, error) {
 		return nil, fmt.Errorf("invalid parameters: %w. Expected fields: deviceId, text", err)
 	}
 
+	if clipboardParams.Text == nil {
+		return nil, fmt.Errorf("'text' is required")
+	}
+
 	response := commands.ClipboardSetCommand(commands.ClipboardSetRequest{
 		DeviceID: clipboardParams.DeviceID,
-		Text:     clipboardParams.Text,
+		Text:     *clipboardParams.Text,
 	})
 	if response.Status == "error" {
 		return nil, fmt.Errorf("%s", response.Error)

--- a/server/server.go
+++ b/server/server.go
@@ -548,6 +548,54 @@ func handleIoSwipe(params json.RawMessage) (any, error) {
 	return okResponse, nil
 }
 
+type ClipboardGetParams struct {
+	DeviceID string `json:"deviceId"`
+}
+
+type ClipboardSetParams struct {
+	DeviceID string `json:"deviceId"`
+	Text     string `json:"text"`
+}
+
+func handleClipboardGet(params json.RawMessage) (any, error) {
+	var clipboardParams ClipboardGetParams
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &clipboardParams); err != nil {
+			return nil, fmt.Errorf("invalid parameters: %w. Expected fields: deviceId", err)
+		}
+	}
+
+	response := commands.ClipboardGetCommand(commands.ClipboardGetRequest{
+		DeviceID: clipboardParams.DeviceID,
+	})
+	if response.Status == "error" {
+		return nil, fmt.Errorf("%s", response.Error)
+	}
+
+	return response.Data, nil
+}
+
+func handleClipboardSet(params json.RawMessage) (any, error) {
+	if len(params) == 0 {
+		return nil, fmt.Errorf("'params' is required with fields: deviceId, text")
+	}
+
+	var clipboardParams ClipboardSetParams
+	if err := json.Unmarshal(params, &clipboardParams); err != nil {
+		return nil, fmt.Errorf("invalid parameters: %w. Expected fields: deviceId, text", err)
+	}
+
+	response := commands.ClipboardSetCommand(commands.ClipboardSetRequest{
+		DeviceID: clipboardParams.DeviceID,
+		Text:     clipboardParams.Text,
+	})
+	if response.Status == "error" {
+		return nil, fmt.Errorf("%s", response.Error)
+	}
+
+	return okResponse, nil
+}
+
 type IoTextParams struct {
 	DeviceID string `json:"deviceId"`
 	Text     string `json:"text"`

--- a/skills/mobilecli/SKILL.md
+++ b/skills/mobilecli/SKILL.md
@@ -104,6 +104,8 @@ Here is a quick reference table mapping standard user actions to their `mobilecl
 | **Swipe** | `mobilecli io swipe <x1,y1,x2,y2>` | `device.io.swipe` | Drag from start to end coordinates |
 | **Type Text** | `mobilecli io text "<text>"` | `device.io.text` | Send raw text to the focused field |
 | **Key Press** | `mobilecli io button <BUTTON_NAME>` | `device.io.button` | Press hardware buttons (e.g. HOME, POWER) |
+| **Read Clipboard** | `mobilecli io clipboard get` | `device.clipboard.get` | Read text from the device clipboard |
+| **Write Clipboard** | `mobilecli io clipboard set "<text>"` | `device.clipboard.set` | Replace text on the device clipboard |
 
 ---
 
@@ -208,6 +210,14 @@ All commands support the global `--device <id>` flag to specify the target devic
   # Android only: BACK, ENTER, BACKSPACE, APP_SWITCH,
   #               DPAD_UP, DPAD_DOWN, DPAD_LEFT, DPAD_RIGHT, DPAD_CENTER
   mobilecli io button --device <device-id> HOME
+  ```
+* **Clipboard**:
+  ```bash
+  # Read the device clipboard
+  mobilecli io clipboard get --device <device-id>
+
+  # Write to the device clipboard
+  mobilecli io clipboard set --device <device-id> "Hello World"
   ```
 
 ### 5. UI Inspection & Webviews

--- a/test/simulator.spec.ts
+++ b/test/simulator.spec.ts
@@ -217,6 +217,28 @@ test.describe('iOS Simulator Tests', () => {
 				verifySpringBoardIsForeground(foregroundAfterHome);
 			});
 
+			test('should set and read back clipboard text', async () => {
+				test.skip(!simulatorId, 'simulator not found');
+
+				const text = `mobilecli-${randomUUID()}`;
+				setClipboard(simulatorId, text);
+				expect(getClipboard(simulatorId)).toBe(text);
+			});
+
+			test('should clear the clipboard when set to an empty string', async () => {
+				test.skip(!simulatorId, 'simulator not found');
+
+				setClipboard(simulatorId, 'not empty');
+				setClipboard(simulatorId, '');
+				expect(getClipboard(simulatorId)).toBe('');
+			});
+
+			test('should reject clipboard set without a text argument', async () => {
+				test.skip(!simulatorId, 'simulator not found');
+
+				expect(() => mobilecli(['io', 'clipboard', 'set', '--device', simulatorId])).toThrow();
+			});
+
 			test.skip('should test device lifecycle: boot, reboot, shutdown', async () => {
 				// shutdown simulator using simctl to get it offline
 				shutdownSimulator(simulatorId);
@@ -548,6 +570,15 @@ function tap(simulatorId: string, x: number, y: number): void {
 
 function pressButton(simulatorId: string, button: string): void {
 	mobilecli(['io', 'button', button, '--device', simulatorId]);
+}
+
+function setClipboard(simulatorId: string, text: string): void {
+	mobilecli(['io', 'clipboard', 'set', text, '--device', simulatorId]);
+}
+
+function getClipboard(simulatorId: string): string {
+	const response = mobilecli(['io', 'clipboard', 'get', '--device', simulatorId]);
+	return response.data.text;
 }
 
 function verifyElementExists(uiDump: UIDumpResponse, name: string): void {


### PR DESCRIPTION
## Summary
CLI side of the clipboard support in mobile-next/devicekit-ios#64. Adds `mobilecli clipboard get` / `set`, plus `device.clipboard.get` / `device.clipboard.set` over JSON-RPC.

Verified on an iPhone 11 (iOS 26.6): set/get round trip, and reading text copied in another app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CLI commands to read, update, and clear device clipboard contents.
  - Added clipboard support for Android, iOS, simulators, remote devices, and connected devices.
  - Added optional device selection with automatic device resolution when unspecified.
  - Added JSON-RPC operations for retrieving and updating clipboard text.
  - Added usage examples and validation for required clipboard text input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->