### PR TITLE
fix(ios): re-tap record button while waiting for broadcast picker

### DIFF
--- a/devices/ios.go
+++ b/devices/ios.go
@@ -1167,29 +1167,11 @@ type DeviceKitInfo struct {
 // clickStartBroadcastButton polls for the "BroadcastUploadExtension" button, taps it,
 // then polls for the "Start Broadcast" button and taps it
 func (d *IOSDevice) clickStartBroadcastButton() error {
-	// first dump: handle "Press to Start Broadcasting" screen if present
-	firstElements, err := d.DumpSource()
-	if err == nil {
-		if hasText(firstElements, "BroadcastUploadExtension") {
-			// dialog is already open, no need to click anything
-			utils.Verbose("It seems that the start broadcasting dialog is already visible")
-		} else if hasText(firstElements, "Press to Start Broadcasting") {
-			utils.Verbose("Found 'Press to Start Broadcasting' screen; tapping the only button.")
-			buttons := filterButtons(firstElements)
-			if len(buttons) != 1 {
-				return fmt.Errorf("expected exactly one button on 'Press to Start Broadcasting' screen, found %d", len(buttons))
-			}
-
-			centerX := buttons[0].Rect.X + buttons[0].Rect.Width/2
-			centerY := buttons[0].Rect.Y + buttons[0].Rect.Height/2
-			utils.Verbose("Tapping at %f,%f", centerX, centerY)
-			if err = d.Tap(centerX, centerY); err != nil {
-				return fmt.Errorf("failed to tap broadcast button: %w", err)
-			}
-		}
-	}
-
-	// first, find and tap "BroadcastUploadExtension"
+	// Poll until the broadcast picker's "BroadcastUploadExtension" entry shows up,
+	// re-tapping the app's record button on every tick where the app screen (and not
+	// the picker) is visible. A single up-front dump is not enough: right after launch
+	// the dump can error or catch the app before it rendered, and skipping the record
+	// tap then means the picker never opens and the old wait loop timed out.
 	utils.Verbose("Waiting for BroadcastUploadExtension button to appear...")
 	var broadcastExtensionButton *ScreenElement
 	timeout := time.After(10 * time.Second)
@@ -1214,6 +1196,23 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 					break
 				}
 			}
+			if broadcastExtensionButton != nil {
+				break
+			}
+
+			// picker not open yet: tap the record button whenever the app screen is up
+			if hasText(elements, "Press to Start Broadcasting") {
+				buttons := filterButtons(elements)
+				if len(buttons) != 1 {
+					return fmt.Errorf("expected exactly one button on 'Press to Start Broadcasting' screen, found %d", len(buttons))
+				}
+				centerX := buttons[0].Rect.X + buttons[0].Rect.Width/2
+				centerY := buttons[0].Rect.Y + buttons[0].Rect.Height/2
+				utils.Verbose("Tapping record button at %f,%f", centerX, centerY)
+				if err = d.Tap(centerX, centerY); err != nil {
+					return fmt.Errorf("failed to tap broadcast button: %w", err)
+				}
+			}
 		}
 	}
 
@@ -1224,8 +1223,7 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 	centerY := broadcastExtensionButton.Rect.Y + broadcastExtensionButton.Rect.Height/2
 	utils.Verbose("Tapping BroadcastUploadExtension button at (%d, %d)", centerX, centerY)
 
-	err = d.Tap(centerX, centerY)
-	if err != nil {
+	if err := d.Tap(centerX, centerY); err != nil {
 		return fmt.Errorf("failed to tap BroadcastUploadExtension button: %w", err)
 	}
 
@@ -1264,8 +1262,7 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 	centerY = startBroadcastButton.Rect.Y + startBroadcastButton.Rect.Height/2
 	utils.Verbose("Tapping Start Broadcast button at (%d, %d)", centerX, centerY)
 
-	err = d.Tap(centerX, centerY)
-	if err != nil {
+	if err := d.Tap(centerX, centerY); err != nil {
 		return fmt.Errorf("failed to tap Start Broadcast button: %w", err)
 	}
 


### PR DESCRIPTION
## The bug
iOS screen capture in the fleet fails with `timeout waiting for BroadcastUploadExtension button to appear`, which the client reports as **"no decodable video within 10s: stream negotiated but no frames reached the track"** — the production iOS no-video failure.

`clickStartBroadcastButton` (devices/ios.go) dumped the screen **once** right after launching the h264 app:
- a dump error was silently swallowed (`if err == nil { … }`), skipping the record-button tap;
- a dump that raced the app's first render found neither "Press to Start Broadcasting" nor the picker, also skipping the tap.

Either way the broadcast picker never opened, and the subsequent 10s poll waited for an element nothing had spawned.

## Evidence (live Device Farm iPhone 16 Pro, iOS 26.0)
- Automated flow: `Error starting screen capture: failed to start DeviceKit: failed to click Start Broadcast button: timeout waiting for BroadcastUploadExtension button to appear` (farm TestSpecOutput).
- Same device, same taps done manually via RPC: picker opens, `device.dump.ui` sees both `BroadcastUploadExtension` and `Start Broadcast`, and after tapping Start Broadcast **video flows end-to-end in the browser**. The h264 app, extension, and WebRTC pipeline are all healthy — only the initial tap was missing.

## The fix
Move the record-button tap inside the poll loop: each 100ms tick re-dumps, taps the record button whenever the app screen is visible, and proceeds once the picker entry appears. Dump errors just retry instead of silently skipping the tap.

## Test plan
- [x] `go build ./...`, `go vet`, `go test ./devices/`
- [ ] release + farm rollout, then allocate an iOS device and confirm video connects with no manual intervention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS broadcast startup reliability by retrying the start action when the broadcasting screen takes longer to appear.
  * Added better handling for temporary UI loading or inspection errors during broadcast initiation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->