### PR TITLE
fix(ios): search nested element tree when waiting for broadcast picker buttons

### DIFF
--- a/devices/ios.go
+++ b/devices/ios.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1178,16 +1179,23 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
+	var lastElements []ScreenElement
 	for broadcastExtensionButton == nil {
 		select {
 		case <-timeout:
-			return fmt.Errorf("timeout waiting for BroadcastUploadExtension button to appear")
+			dump, err := json.Marshal(lastElements)
+			if err != nil {
+				dump = []byte(err.Error())
+			}
+			return fmt.Errorf("timeout waiting for BroadcastUploadExtension button to appear, last element dump: %s", dump)
 		case <-ticker.C:
 			elements, err := d.DumpSource()
 			if err != nil {
 				// continue trying on error
 				continue
 			}
+			elements = flattenElements(elements)
+			lastElements = elements
 
 			// find the "BroadcastUploadExtension" button
 			for i := range elements {
@@ -1244,6 +1252,7 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 				// continue trying on error
 				continue
 			}
+			elements = flattenElements(elements)
 
 			// find the "Start Broadcast" button
 			for i := range elements {
@@ -1267,6 +1276,17 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 	}
 
 	return nil
+}
+
+// flattenElements returns the element tree as a flat depth-first list,
+// since DumpSource now returns nested children.
+func flattenElements(elements []ScreenElement) []ScreenElement {
+	var flat []ScreenElement
+	for i := range elements {
+		flat = append(flat, elements[i])
+		flat = append(flat, flattenElements(elements[i].Children)...)
+	}
+	return flat
 }
 
 func hasText(elements []ScreenElement, text string) bool {

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -1242,10 +1242,15 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 	ticker = time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
+	lastElements = nil
 	for startBroadcastButton == nil {
 		select {
 		case <-timeout:
-			return fmt.Errorf("timeout waiting for Start Broadcast button to appear")
+			dump, err := json.Marshal(lastElements)
+			if err != nil {
+				dump = []byte(err.Error())
+			}
+			return fmt.Errorf("timeout waiting for Start Broadcast button to appear, last element dump: %s", dump)
 		case <-ticker.C:
 			elements, err := d.DumpSource()
 			if err != nil {
@@ -1253,6 +1258,7 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 				continue
 			}
 			elements = flattenElements(elements)
+			lastElements = elements
 
 			// find the "Start Broadcast" button
 			for i := range elements {

--- a/devices/ios_elements_test.go
+++ b/devices/ios_elements_test.go
@@ -1,0 +1,24 @@
+package devices
+
+import "testing"
+
+func TestFlattenElementsIncludesNestedChildren(t *testing.T) {
+	name := "BroadcastUploadExtension"
+	tree := []ScreenElement{
+		{
+			Type: "Window",
+			Children: []ScreenElement{
+				{Type: "Button", Name: &name},
+			},
+		},
+	}
+
+	flat := flattenElements(tree)
+
+	if len(flat) != 2 {
+		t.Fatalf("expected 2 elements after flatten, got %d", len(flat))
+	}
+	if flat[1].Name == nil || *flat[1].Name != name {
+		t.Errorf("expected nested button to be flattened, got %+v", flat[1])
+	}
+}


### PR DESCRIPTION
## Why
On a live fleet iPhone 17 running 1.0.3, screen capture kept failing with `timeout waiting for BroadcastUploadExtension button to appear` — even though the broadcast picker was open on screen. Dumping the last element tree on timeout (now part of the error message) showed why: the `BroadcastUploadExtension` and `Start Broadcast` buttons were present, but nested inside `SBTransientOverlayWindow`'s `children`. The element dump became a tree, while `clickStartBroadcastButton` still scanned only the top-level slice, so it never found either button.

This replaces the earlier approach on this branch of bumping the wait from 10s to 30s — no amount of waiting helps when the search never descends into children, so the timeouts stay at 10s.

## What
- `clickStartBroadcastButton` flattens each `DumpSource()` result (depth-first) before searching, so the button lookup, `hasText`, and `filterButtons` all see nested elements.
- On timeout, the error now includes the JSON of the last element dump to make future failures diagnosable.
- Added a unit test covering `flattenElements` with nested children.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broadcast picker handling when controls are nested within other interface elements.
  * Timeout diagnostics now include a readable dump of the last observed interface state.
  * Improved detection of the “Start Broadcast” button in complex picker layouts.

* **Tests**
  * Added coverage for discovering nested elements and preserving their names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->