### PR TITLE
fix(ios): start recording time limit and progress ticker when capture is live

### DIFF
--- a/commands/screenrecord.go
+++ b/commands/screenrecord.go
@@ -120,6 +120,7 @@ type screenRecordProgress struct {
 	stopOnce    sync.Once
 	tickerDone  chan struct{}
 	endedCalled bool
+	wasStarted  bool
 }
 
 func newScreenRecordProgress(req ScreenRecordRequest) *screenRecordProgress {
@@ -131,6 +132,7 @@ func newScreenRecordProgress(req ScreenRecordRequest) *screenRecordProgress {
 }
 
 func (p *screenRecordProgress) started() {
+	p.wasStarted = true
 	if p.silent {
 		return
 	}
@@ -174,6 +176,10 @@ func (p *screenRecordProgress) recordingEnded() {
 	}
 	p.stopTicker()
 	p.endedCalled = true
+	// nothing to report if capture failed before it ever started
+	if !p.wasStarted {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "\nScreen recording ended, please wait while finalizing video\n")
 }
 
@@ -207,9 +213,6 @@ func screenRecordIOSDevice(targetDevice devices.ControllableDevice, req ScreenRe
 		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
 	}
 
-	progress.started()
-	progress.startTicker()
-
 	err = targetDevice.StartScreenCapture(devices.ScreenCaptureConfig{
 		Format:  "avc",
 		Quality: devices.DefaultQuality,
@@ -218,7 +221,12 @@ func screenRecordIOSDevice(targetDevice devices.ControllableDevice, req ScreenRe
 		OnProgress: func(message string) {
 			utils.Verbose(message)
 		},
+		// started/startTicker live here rather than before StartScreenCapture so
+		// the displayed timer doesn't run during the ~10s DeviceKit/broadcast
+		// picker setup.
 		OnReady: func() {
+			progress.started()
+			progress.startTicker()
 			req.signalReady(nil)
 		},
 		OnData: withStopChan(func(data []byte) bool {
@@ -328,14 +336,17 @@ func withStopChan(onData func([]byte) bool, timeLimitSec int, stopChan <-chan st
 		return onData
 	}
 
+	// the deadline starts at the first data frame, not at wrap time: on real iOS
+	// devices setup (DeviceKit + broadcast picker) can take ~10s, which would
+	// otherwise expire a short time limit before any frame arrives.
 	var deadline time.Time
-	if hasTimeLimit {
-		deadline = time.Now().Add(time.Duration(timeLimitSec) * time.Second)
-	}
-
 	return func(data []byte) bool {
-		if hasTimeLimit && time.Now().After(deadline) {
-			return false
+		if hasTimeLimit {
+			if deadline.IsZero() {
+				deadline = time.Now().Add(time.Duration(timeLimitSec) * time.Second)
+			} else if time.Now().After(deadline) {
+				return false
+			}
 		}
 		if hasStopChan {
 			select {

--- a/commands/screenrecord_test.go
+++ b/commands/screenrecord_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithStopChanTimeLimitStartsAtFirstFrameNotAtWrapTime(t *testing.T) {
+	onData := withStopChan(func([]byte) bool { return true }, 1, nil)
+
+	// simulate slow capture setup (e.g. iOS broadcast picker) taking longer
+	// than the time limit before the first frame arrives
+	time.Sleep(1100 * time.Millisecond)
+
+	if !onData(nil) {
+		t.Fatal("first frame after slow setup should be accepted; time limit must start at first frame")
+	}
+}
+
+func TestWithStopChanStopsAfterTimeLimitElapsedSinceFirstFrame(t *testing.T) {
+	onData := withStopChan(func([]byte) bool { return true }, 1, nil)
+
+	if !onData(nil) {
+		t.Fatal("first frame should be accepted")
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if onData(nil) {
+		t.Fatal("frame after time limit elapsed should stop the recording")
+	}
+}


### PR DESCRIPTION
## Summary
When prewarming a real iOS device for WebRTC by recording a 1-second video, both the recording time limit and the on-screen timer started before capture was actually live: `withStopChan` computed its deadline when the `ScreenCaptureConfig` was built, and the progress ticker started before `StartScreenCapture` — but on real devices setup (DeviceKit launch + broadcast picker flow) takes ~10s. A 1s limit therefore expired before the first H.264 frame arrived, so the very first `OnData` returned false and the "recording" captured essentially nothing, while the terminal showed `Screen recording for 00:11 seconds (time limit 00:01)`.

## Changes
- `withStopChan` now starts the time-limit deadline at the first data frame instead of at wrap time, so a 1s limit records 1s of actual video regardless of setup duration.
- The `started()` message and elapsed-time ticker moved into `OnReady` for the real-iOS path, so the displayed timer matches when frames can actually flow.
- `recordingEnded()` no longer prints "Screen recording ended" when capture failed before ever starting.
- Added regression tests for both `withStopChan` behaviors (limit starts at first frame; limit still enforced after it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen-recording status messages when capture fails before starting.
  * Recording timers now begin when capture is confirmed live or the first frame arrives.
  * Prevented slow setup time from reducing the configured recording duration.
  * Ensured frames are accepted during the recording window and rejected after the time limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->