### PR TITLE
ci: use golangci-lint-action prebuilt binary instead of compiling from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.2.2
+        version: v2.13.1
       continue-on-error: true
 
   security:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,9 @@ jobs:
         go fmt ./...
         git diff --exit-code
 
+    - name: Create placeholder agent binaries for typecheck
+      run: touch agents/android/mobilecli.so agents/android/mobilecli.dex agents/ios/agent-sim.dylib
+
     - name: Lint
       uses: golangci/golangci-lint-action@v8
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,20 +118,16 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: Install dependencies
-      run: |
-        go install golang.org/x/tools/cmd/goimports@latest
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
     - name: Check formatting
       run: |
         go fmt ./...
         git diff --exit-code
 
     - name: Lint
-      run: |
-        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.2
-        make lint || true
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.2.2
+      continue-on-error: true
 
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,7 @@ jobs:
       uses: golangci/golangci-lint-action@v8
       with:
         version: v2.13.1
+        verify: false
       continue-on-error: true
 
   security:


### PR DESCRIPTION
The lint job took ~2 minutes, almost all of it compiling golangci-lint from source twice per run: once `@latest` (v1, unused) in Install dependencies (~44s) and again `@v2.2.2` in the Lint step (~80s).

This switches to the official golangci-lint-action, which downloads a prebuilt binary and caches analysis, and removes the unused goimports/golangci-lint v1 installs. Lint stays non-blocking (`continue-on-error: true` replaces `make lint || true`) since there are 41 outstanding lint issues.

Expected job time: ~30-40s instead of ~2m50s.