### PR TITLE
feat(ios): live AVC bitrate control and keyframe requests

### DIFF
--- a/devices/avc_control.go
+++ b/devices/avc_control.go
@@ -15,39 +15,46 @@ import (
 // forward host stdin to the device process.
 const avcControlSocket = "devicekit-avc"
 
-// SetAvcBitrate changes the bitrate of an in-flight Android AVC capture without
-// restarting the stream. Returns an error for non-Android devices (iOS uses
-// MJPEG, which has no live control channel).
+// SetAvcBitrate changes the bitrate of an in-flight AVC capture without
+// restarting the stream. Both platforms accept the same payload
+// ("screencapture.setBitrate" with a "bps" param); only the transport differs —
+// Android over the localabstract control socket, iOS over the live stream conn.
 func SetAvcBitrate(device ControllableDevice, bitrate int) error {
-	android, ok := device.(*AndroidDevice)
-	if !ok {
-		return fmt.Errorf("live bitrate control is only supported for Android AVC captures")
+	switch dev := device.(type) {
+	case *AndroidDevice:
+		port, err := dev.ensureControlForward()
+		if err != nil {
+			return err
+		}
+		if _, err := agentRequest(port, "screencapture.setBitrate", map[string]any{"bps": bitrate}); err != nil {
+			return fmt.Errorf("set AVC bitrate: %w", err)
+		}
+		return nil
+	case *IOSDevice:
+		return dev.sendAvcControl("screencapture.setBitrate", map[string]any{"bps": bitrate})
+	default:
+		return fmt.Errorf("live bitrate control is not supported for this device type")
 	}
-	port, err := android.ensureControlForward()
-	if err != nil {
-		return err
-	}
-	if _, err := agentRequest(port, "screencapture.setBitrate", map[string]any{"bps": bitrate}); err != nil {
-		return fmt.Errorf("set AVC bitrate: %w", err)
-	}
-	return nil
 }
 
-// RequestAvcKeyFrame asks the in-flight Android AVC encoder for an immediate sync
+// RequestAvcKeyFrame asks the in-flight AVC encoder for an immediate sync
 // frame (e.g. in response to a viewer PLI).
 func RequestAvcKeyFrame(device ControllableDevice) error {
-	android, ok := device.(*AndroidDevice)
-	if !ok {
-		return fmt.Errorf("keyframe request is only supported for Android AVC captures")
+	switch dev := device.(type) {
+	case *AndroidDevice:
+		port, err := dev.ensureControlForward()
+		if err != nil {
+			return err
+		}
+		if _, err := agentRequest(port, "screencapture.requestKeyFrame", nil); err != nil {
+			return fmt.Errorf("request AVC keyframe: %w", err)
+		}
+		return nil
+	case *IOSDevice:
+		return dev.sendAvcControl("screencapture.requestKeyFrame", nil)
+	default:
+		return fmt.Errorf("keyframe request is not supported for this device type")
 	}
-	port, err := android.ensureControlForward()
-	if err != nil {
-		return err
-	}
-	if _, err := agentRequest(port, "screencapture.requestKeyFrame", nil); err != nil {
-		return fmt.Errorf("request AVC keyframe: %w", err)
-	}
-	return nil
 }
 
 // ensureControlForward returns a host TCP port forwarded to the AvcServer control

--- a/devices/avc_control_test.go
+++ b/devices/avc_control_test.go
@@ -1,0 +1,82 @@
+package devices
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"net"
+	"testing"
+)
+
+// readControlMessage reads one length-prefixed JSON-RPC message the way the
+// broadcast extension's ScreenStreamer does: 4-byte big-endian length, then payload.
+func readControlMessage(t *testing.T, conn net.Conn) map[string]any {
+	t.Helper()
+
+	header := make([]byte, 4)
+	if _, err := conn.Read(header); err != nil {
+		t.Fatalf("read length prefix: %v", err)
+	}
+	payload := make([]byte, binary.BigEndian.Uint32(header))
+	if _, err := conn.Read(payload); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+
+	var msg map[string]any
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		t.Fatalf("payload is not valid JSON: %v", err)
+	}
+	return msg
+}
+
+func TestSetAvcBitrateSendsAndroidCompatiblePayloadOnStreamConn(t *testing.T) {
+	local, remote := net.Pipe()
+	defer func() { _ = local.Close() }()
+	defer func() { _ = remote.Close() }()
+
+	dev := &IOSDevice{avcStreamConn: local}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- SetAvcBitrate(dev, 4_000_000) }()
+
+	msg := readControlMessage(t, remote)
+	if err := <-errCh; err != nil {
+		t.Fatalf("SetAvcBitrate: %v", err)
+	}
+
+	if msg["method"] != "screencapture.setBitrate" {
+		t.Errorf("method = %v, want screencapture.setBitrate", msg["method"])
+	}
+	params, ok := msg["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("params missing or not an object: %v", msg["params"])
+	}
+	if params["bps"] != float64(4_000_000) {
+		t.Errorf("params.bps = %v, want 4000000", params["bps"])
+	}
+}
+
+func TestRequestAvcKeyFrameSendsMethodOnStreamConn(t *testing.T) {
+	local, remote := net.Pipe()
+	defer func() { _ = local.Close() }()
+	defer func() { _ = remote.Close() }()
+
+	dev := &IOSDevice{avcStreamConn: local}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- RequestAvcKeyFrame(dev) }()
+
+	msg := readControlMessage(t, remote)
+	if err := <-errCh; err != nil {
+		t.Fatalf("RequestAvcKeyFrame: %v", err)
+	}
+
+	if msg["method"] != "screencapture.requestKeyFrame" {
+		t.Errorf("method = %v, want screencapture.requestKeyFrame", msg["method"])
+	}
+}
+
+func TestSetAvcBitrateFailsWithoutActiveStream(t *testing.T) {
+	if err := SetAvcBitrate(&IOSDevice{}, 4_000_000); err == nil {
+		t.Fatal("expected error when no capture stream is active")
+	}
+}

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -82,6 +83,9 @@ type IOSDevice struct {
 	portForwarderMjpeg          *ios.PortForwarder
 	portForwarderDeviceKit      *ios.PortForwarder // devicekit http forwarder
 	portForwarderAvc            *ios.PortForwarder // devicekit h264 stream forwarder
+	avcStreamConn               net.Conn           // live h264 stream conn, doubles as the control channel
+
+	avcWriteMu sync.Mutex // serializes control writes on avcStreamConn
 }
 
 func (d *IOSDevice) ID() string {
@@ -950,6 +954,40 @@ func (d *IOSDevice) Info() (*FullDeviceInfo, error) {
 	}, nil
 }
 
+// sendAvcControl sends a live encoder control message to the broadcast
+// extension as length-prefixed JSON-RPC (4-byte big-endian length + payload)
+// on the running H.264 stream connection. Fire-and-forget: the extension
+// sends no responses on this channel.
+func (d *IOSDevice) sendAvcControl(method string, params map[string]any) error {
+	d.mu.Lock()
+	conn := d.avcStreamConn
+	d.mu.Unlock()
+	if conn == nil {
+		return fmt.Errorf("no active H.264 capture stream")
+	}
+
+	msg, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+		"id":      1,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", method, err)
+	}
+
+	buf := make([]byte, 4+len(msg))
+	binary.BigEndian.PutUint32(buf, uint32(len(msg)))
+	copy(buf[4:], msg)
+
+	d.avcWriteMu.Lock()
+	defer d.avcWriteMu.Unlock()
+	if _, err := conn.Write(buf); err != nil {
+		return fmt.Errorf("send %s: %w", method, err)
+	}
+	return nil
+}
+
 func (d *IOSDevice) StartScreenCapture(config ScreenCaptureConfig) error {
 	// handle avc format via DeviceKit
 	if config.Format == "avc" {
@@ -1022,6 +1060,21 @@ func (d *IOSDevice) StartScreenCapture(config ScreenCaptureConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to connect to stream port: %w", err)
 		}
+
+		// Expose the stream conn as the live encoder control channel. Control
+		// must ride this exact conn: the extension's TCPServer redirects video
+		// output to its newest client, so a separate control connection would
+		// steal the stream.
+		d.mu.Lock()
+		d.avcStreamConn = conn
+		d.mu.Unlock()
+		defer func() {
+			d.mu.Lock()
+			if d.avcStreamConn == conn {
+				d.avcStreamConn = nil
+			}
+			d.mu.Unlock()
+		}()
 
 		// setup signal handling for Ctrl+C
 		sigChan := make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary

- `SetAvcBitrate`/`RequestAvcKeyFrame` previously rejected iOS devices (a leftover from the MJPEG days), leaving the adaptive-bitrate feedback loop dead on iOS: the device encoder ran uncapped for the entire session — observed 22–38 Mbps for a 602×1310 stream, saturating the path (RTT 180–480ms with spikes past 1.4s).
- Both platforms now accept the same JSON-RPC payload (`screencapture.setBitrate` with `bps`, `screencapture.requestKeyFrame`); only the transport differs — Android over the localabstract control socket, iOS as length-prefixed JSON written on the live H.264 stream connection.
- The control write must ride that exact conn: the broadcast extension's `TCPServer` redirects video output to its newest client, so a separate control connection would steal the stream. The conn is stashed on `IOSDevice` when the AVC capture dials in and cleared when the stream ends.
- Adds tests covering the wire framing (4-byte big-endian length + JSON), the Android-compatible payload, and the no-active-stream error.

Stacked on #357 (pointer receivers) — the conn stash requires `*IOSDevice` instances in the device cache. Device side: mobile-next/devicekit-ios-h264#5.