### PR TITLE
fix(ios): use simctl pbcopy/pbpaste for simulator clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ mobilecli io clipboard get --device <device-id>
 
 # Write device clipboard
 mobilecli io clipboard set --device <device-id> 'hello world'
+
+# Send keys combination to paste (cmd+v for iOS)
+mobilecli io keys --device <device-id> "cmd+v"
 ```
 
 ### Supported Hardware Buttons

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -587,11 +587,22 @@ func (s SimulatorDevice) Swipe(x1, y1, x2, y2, duration int) error {
 }
 
 func (s SimulatorDevice) GetClipboard() (string, error) {
-	return s.deviceKitClient.GetClipboard()
+	// #nosec G204 -- udid is controlled, no shell interpretation
+	output, err := exec.Command("xcrun", "simctl", "pbpaste", s.ID()).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get clipboard: %w", err)
+	}
+	return string(output), nil
 }
 
 func (s SimulatorDevice) SetClipboard(text string) error {
-	return s.deviceKitClient.SetClipboard(text)
+	// #nosec G204 -- udid is controlled, no shell interpretation
+	cmd := exec.Command("xcrun", "simctl", "pbcopy", s.ID())
+	cmd.Stdin = strings.NewReader(text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to set clipboard: %w", err)
+	}
+	return nil
 }
 
 func (s SimulatorDevice) Gesture(actions []devicekit.TapAction) error {


### PR DESCRIPTION
## Summary
- Simulator clipboard get/set now shells out to `xcrun simctl pbpaste`/`pbcopy` instead of going through the devicekit agent, so it no longer relies on the Pasteboard API
- Real iOS devices are unchanged (still via devicekit, simctl can't reach physical device pasteboards)
- README: document `io keys "cmd+v"` for pasting clipboard contents