### PR TITLE
fix: correct tap log format verb and openrpc allocationId schema drift

### DIFF
--- a/devices/ios.go
+++ b/devices/ios.go
@@ -1286,7 +1286,7 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 				}
 				centerX := buttons[0].Rect.X + buttons[0].Rect.Width/2
 				centerY := buttons[0].Rect.Y + buttons[0].Rect.Height/2
-				utils.Verbose("Tapping record button at %f,%f", centerX, centerY)
+				utils.Verbose("Tapping record button at %d,%d", centerX, centerY)
 				if err = d.Tap(centerX, centerY); err != nil {
 					return fmt.Errorf("failed to tap broadcast button: %w", err)
 				}

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1825,9 +1825,9 @@
             "type": "string",
             "description": "Provider type (e.g. 'mobilenext', 'local')"
           },
-          "sessionId": {
+          "allocationId": {
             "type": "string",
-            "description": "Session identifier for this device allocation"
+            "description": "Allocation identifier for this device"
           }
         },
         "required": [

--- a/docs/openrpc.md
+++ b/docs/openrpc.md
@@ -1768,7 +1768,7 @@ Describes where the device is provided from
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `type` | `string` | ✓ | Provider type (e.g. 'mobilenext', 'local') |
-| `sessionId` | `string` |  | Session identifier for this device allocation |
+| `allocationId` | `string` |  | Allocation identifier for this device |
 
 ### Rect
 


### PR DESCRIPTION
## Summary

Two small review fixes: a wrong format verb in a verbose log, and OpenRPC schema drift for the DeviceProvider allocation field.

## Changes

- `devices/ios.go` — the record-button tap log used `%f` for `centerX`/`centerY`, which are `int` (printed `%!f(int=...)`); now `%d,%d`.
- `docs/openrpc.json` — `DeviceProvider` schema declared `sessionId`, but the Go struct serializes `allocationId` (`devices/common.go`) and `findDeviceByAllocation` matches on `allocationId`; renamed the property to match.
- `docs/openrpc.md` — regenerated via `make docs`.