### PR TITLE
fix: don't fail device listing when one iOS device is untrusted

### DIFF
--- a/devices/ios.go
+++ b/devices/ios.go
@@ -171,13 +171,24 @@ func ListIOSDevices() ([]*IOSDevice, error) {
 		return nil, fmt.Errorf("failed getting device list: %w", err)
 	}
 
-	devices := make([]*IOSDevice, len(deviceList.DeviceList))
-	for i, deviceEntry := range deviceList.DeviceList {
+	// go-ios returns one entry per connection (usb, network), dedupe by udid.
+	// a device that fails getDeviceInfo (untrusted, locked) is skipped so it
+	// does not hide the remaining devices.
+	devices := make([]*IOSDevice, 0, len(deviceList.DeviceList))
+	seen := make(map[string]bool)
+	for _, deviceEntry := range deviceList.DeviceList {
+		udid := deviceEntry.Properties.SerialNumber
+		if seen[udid] {
+			continue
+		}
+		seen[udid] = true
+
 		device, err := getDeviceInfo(deviceEntry)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get device info: %w", err)
+			utils.Verbose("Warning: skipping device %s: %v", udid, err)
+			continue
 		}
-		devices[i] = device
+		devices = append(devices, device)
 	}
 
 	return devices, nil

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -181,13 +181,13 @@ func ListIOSDevices() ([]*IOSDevice, error) {
 		if seen[udid] {
 			continue
 		}
-		seen[udid] = true
 
 		device, err := getDeviceInfo(deviceEntry)
 		if err != nil {
 			utils.Verbose("Warning: skipping device %s: %v", udid, err)
 			continue
 		}
+		seen[udid] = true
 		devices = append(devices, device)
 	}
 


### PR DESCRIPTION
Fixes #346.

`ListIOSDevices` aborted the whole listing on the first `getDeviceInfo` error, so a single untrusted or locked iOS device made `mobilecli devices` return an empty list — the caller in `devices/common.go` discards the entire iOS list on error. Failing devices are now skipped with a verbose warning instead.

This also fixes the duplicate entries reported in the same issue: go-ios returns one `DeviceEntry` per connection (USB + Wi-Fi) for the same device, so entries are now deduped by udid.

Note: the flaky behavior in the report is explained by the device-info cache — a previously-trusted device kept listing from cache even after `GetValues` started failing.

## Test plan
- [x] `go build ./...`, `go vet ./devices/`, `go test ./devices/` pass
- [x] Manual: attach one trusted + one untrusted device, verify trusted device still listed
- [ ] Manual: device connected over both USB and Wi-Fi appears once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS device discovery when multiple connection entries reference the same device.
  * Failed connection attempts no longer prevent subsequent entries for that device from being tried.
  * Devices are included in listings only after their information is successfully retrieved, helping ensure more complete and accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->