### PR TITLE
fix: resolve gosec G304 warnings and Node 20 deprecation in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       run: touch agents/android/mobilecli.so agents/android/mobilecli.dex agents/ios/agent-sim.dylib
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9
       with:
         version: v2.13.1
         verify: false

--- a/server/server.go
+++ b/server/server.go
@@ -2086,7 +2086,7 @@ func handleFsPull(params json.RawMessage) (any, error) {
 		return nil, fmt.Errorf("%s", response.Error)
 	}
 
-	data, err := os.ReadFile(tmpPath)
+	data, err := os.ReadFile(tmpPath) // #nosec G304 -- tmpPath comes from os.CreateTemp, not user input
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pulled file: %w", err)
 	}

--- a/utils/appmeta.go
+++ b/utils/appmeta.go
@@ -96,7 +96,7 @@ func parseIpaMetadata(path string) (*AppMetadata, error) {
 }
 
 func parseAppDirMetadata(path string) (*AppMetadata, error) {
-	data, err := os.ReadFile(filepath.Join(path, "Info.plist"))
+	data, err := os.ReadFile(filepath.Join(path, "Info.plist")) // #nosec G304 -- reading Info.plist from caller-specified app bundle is intended
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Info.plist: %w", err)
 	}


### PR DESCRIPTION
- Suppress gosec G304 false positives with `#nosec` annotations: `tmpPath` comes from `os.CreateTemp` and `Info.plist` is read from a caller-specified app bundle — neither is untrusted input.
- Bump `golangci/golangci-lint-action` v8 → v9 so the lint step runs on Node 24, clearing the Node 20 deprecation warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the linting workflow to use the latest supported action version.

* **Security**
  * Improved security-scan handling for validated temporary files and application metadata reads.
  * No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->