### PR TITLE
feat: element refs in dump ui, tap by @ref

### DIFF
--- a/cli/io.go
+++ b/cli/io.go
@@ -16,15 +16,27 @@ var ioCmd = &cobra.Command{
 }
 
 var ioTapCmd = &cobra.Command{
-	Use:   "tap [x,y]",
-	Short: "Tap on a device screen at the given coordinates",
-	Long:  `Sends a tap event to the specified device at the given x,y coordinates. Coordinates should be provided as a single string "x,y".`,
+	Use:   "tap [x,y | @ref]",
+	Short: "Tap on a device screen at the given coordinates or element ref",
+	Long:  `Sends a tap event to the specified device at the given x,y coordinates ("x,y"), or at the center of an element ref from the latest "dump ui" (e.g. "@e5").`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		coordsStr := args[0]
+		if strings.HasPrefix(coordsStr, "@") {
+			response := commands.TapCommand(commands.TapRequest{
+				DeviceID: deviceId,
+				Ref:      coordsStr,
+			})
+			printJson(response)
+			if response.Status == "error" {
+				return fmt.Errorf("%s", response.Error)
+			}
+			return nil
+		}
+
 		parts := strings.Split(coordsStr, ",")
 		if len(parts) != 2 {
-			response := commands.NewErrorResponse(fmt.Errorf("invalid coordinate format. Expected 'x,y', got '%s'", coordsStr))
+			response := commands.NewErrorResponse(fmt.Errorf("invalid target format. Expected 'x,y' coordinates or an element ref like '@e15', got '%s'", coordsStr))
 			printJson(response)
 			return fmt.Errorf("%s", response.Error)
 		}

--- a/commands/dump.go
+++ b/commands/dump.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"github.com/mobile-next/mobilecli/devices"
+	"github.com/mobile-next/mobilecli/types"
 )
 
 // DumpUIRequest represents the parameters for dumping UI tree
@@ -52,6 +53,7 @@ func DumpUICommand(req DumpUIRequest) *CommandResponse {
 			return NewErrorResponse(fmt.Errorf("failed to dump UI from device %s: %w", targetDevice.ID(), err))
 		}
 
+		types.AttachRefs(elements)
 		response = DumpUIResponse{
 			Elements: elements,
 		}

--- a/commands/input.go
+++ b/commands/input.go
@@ -3,16 +3,20 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/mobile-next/mobilecli/devices"
 	"github.com/mobile-next/mobilecli/devices/devicekit"
+	"github.com/mobile-next/mobilecli/types"
 )
 
-// TapRequest represents the parameters for a tap command
+// TapRequest represents the parameters for a tap command. Either X,Y or Ref
+// ("@e5", from the latest dump) must be set; Ref wins when both are set.
 type TapRequest struct {
 	DeviceID string `json:"deviceId"`
 	X        int    `json:"x"`
 	Y        int    `json:"y"`
+	Ref      string `json:"ref,omitempty"`
 }
 
 // LongPressRequest represents the parameters for a long press command
@@ -53,7 +57,7 @@ type SwipeRequest struct {
 
 // TapCommand performs a tap operation on the specified device
 func TapCommand(req TapRequest) *CommandResponse {
-	if req.X < 0 || req.Y < 0 {
+	if req.Ref == "" && (req.X < 0 || req.Y < 0) {
 		return NewErrorResponse(fmt.Errorf("x and y coordinates must be non-negative, got x=%d, y=%d", req.X, req.Y))
 	}
 
@@ -69,14 +73,52 @@ func TapCommand(req TapRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
 	}
 
-	err = targetDevice.Tap(req.X, req.Y)
+	x, y := req.X, req.Y
+	if req.Ref != "" {
+		x, y, err = resolveRefTapPoint(targetDevice, req.Ref)
+		if err != nil {
+			return NewErrorResponse(err)
+		}
+	}
+
+	err = targetDevice.Tap(x, y)
 	if err != nil {
 		return NewErrorResponse(fmt.Errorf("failed to tap on device %s: %v", targetDevice.ID(), err))
 	}
 
 	return NewSuccessResponse(MessageResult{
-		Message: fmt.Sprintf("Tapped on device %s at (%d,%d)", targetDevice.ID(), req.X, req.Y),
+		Message: fmt.Sprintf("Tapped on device %s at (%d,%d)", targetDevice.ID(), x, y),
 	})
+}
+
+// resolveRefTapPoint re-dumps the UI tree, numbers it exactly like "dump ui"
+// does, and returns the center of the element matching ref ("@e5" or "e5").
+// Refs are positional against a fresh dump; there is no staleness tracking.
+func resolveRefTapPoint(device devices.ControllableDevice, ref string) (int, int, error) {
+	elements, err := device.DumpSource()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to dump UI to resolve ref %s: %w", ref, err)
+	}
+
+	types.AttachRefs(elements)
+	element := findElementByRef(elements, strings.TrimPrefix(ref, "@"))
+	if element == nil {
+		return 0, 0, fmt.Errorf("ref %s not found on current screen; refs come from the latest 'dump ui'", ref)
+	}
+
+	return element.Rect.X + element.Rect.Width/2, element.Rect.Y + element.Rect.Height/2, nil
+}
+
+func findElementByRef(elements []types.ScreenElement, ref string) *types.ScreenElement {
+	for i := range elements {
+		if elements[i].Ref == ref {
+			return &elements[i]
+		}
+		if found := findElementByRef(elements[i].Children, ref); found != nil {
+			return found
+		}
+	}
+	return nil
 }
 
 // LongPressCommand performs a long press operation on the specified device

--- a/commands/input_test.go
+++ b/commands/input_test.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/mobile-next/mobilecli/types"
+)
+
+func TestFindElementByRefSearchesNestedChildren(t *testing.T) {
+	elements := []types.ScreenElement{
+		{
+			Type: "window",
+			Children: []types.ScreenElement{
+				{Type: "button", Rect: types.ScreenElementRect{X: 10, Y: 20, Width: 100, Height: 40}},
+			},
+		},
+	}
+	types.AttachRefs(elements)
+
+	element := findElementByRef(elements, "e2")
+	if element == nil {
+		t.Fatal("expected to find e2")
+	}
+	if element.Type != "button" {
+		t.Fatalf("expected button, got %s", element.Type)
+	}
+
+	if findElementByRef(elements, "e99") != nil {
+		t.Fatal("expected e99 to be missing")
+	}
+}

--- a/types/screen.go
+++ b/types/screen.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 type ScreenElementRect struct {
 	X      int `json:"x"`
 	Y      int `json:"y"`
@@ -8,6 +10,7 @@ type ScreenElementRect struct {
 }
 
 type ScreenElement struct {
+	Ref         string            `json:"ref,omitempty"`
 	Type        string            `json:"type"`
 	Label       *string           `json:"label,omitempty"`
 	Text        *string           `json:"text,omitempty"`
@@ -21,4 +24,20 @@ type ScreenElement struct {
 	Checked     *bool             `json:"checked,omitempty"`  // only set when true
 	Selected    *bool             `json:"selected,omitempty"` // only set when true
 	Children    []ScreenElement   `json:"children,omitempty"`
+}
+
+// AttachRefs assigns each element a ref ("e1".."eN") in depth-first pre-order,
+// so a ref is the element's position in the tree as printed. Refs are only
+// valid against the dump that produced them.
+func AttachRefs(elements []ScreenElement) {
+	counter := 0
+	attachRefs(elements, &counter)
+}
+
+func attachRefs(elements []ScreenElement, counter *int) {
+	for i := range elements {
+		*counter++
+		elements[i].Ref = fmt.Sprintf("e%d", *counter)
+		attachRefs(elements[i].Children, counter)
+	}
 }

--- a/types/screen_test.go
+++ b/types/screen_test.go
@@ -1,0 +1,32 @@
+package types
+
+import "testing"
+
+func TestAttachRefsNumbersDepthFirstPreOrder(t *testing.T) {
+	elements := []ScreenElement{
+		{
+			Type: "window",
+			Children: []ScreenElement{
+				{Type: "button"},
+				{Type: "list", Children: []ScreenElement{{Type: "cell"}}},
+			},
+		},
+		{Type: "toolbar"},
+	}
+
+	AttachRefs(elements)
+
+	got := []string{
+		elements[0].Ref,
+		elements[0].Children[0].Ref,
+		elements[0].Children[1].Ref,
+		elements[0].Children[1].Children[0].Ref,
+		elements[1].Ref,
+	}
+	want := []string{"e1", "e2", "e3", "e4", "e5"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ref %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `dump ui` now assigns each element a `ref` (`e1`..`eN`, depth-first pre-order — the element's position in the printed tree).
- `io tap` accepts either `x,y` coordinates or an element ref (`@e5`). A ref is resolved against a fresh dump at tap time and taps the element's rect center. JSON-RPC `device.io.tap` accepts the new `ref` field as well.
- Raw dumps (`--format raw`) are unchanged.

Refs are positional against the latest dump, so they are only valid until the screen changes; no staleness tracking yet.

## Test plan

- `go test ./types ./commands` (new tests for ref numbering and nested ref lookup)
- Manual: `mobilecli dump ui` then `mobilecli io tap @e3`
- Error message check: `io tap e15` suggests both formats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `io tap` now supports tapping UI elements by reference, such as `@e5`, in addition to screen coordinates.
  * Screen element references are included in structured UI information, including nested elements.
  * Reference-based taps automatically target the matched element’s center.

* **Bug Fixes**
  * Improved validation and error reporting for invalid tap targets.

* **Tests**
  * Added coverage for nested element references and reference-based tapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->