### PR TITLE
feat: prefix element refs with @ in dump ui

### DIFF
--- a/commands/input.go
+++ b/commands/input.go
@@ -101,7 +101,7 @@ func resolveRefTapPoint(device devices.ControllableDevice, ref string) (int, int
 	}
 
 	types.AttachRefs(elements)
-	element := findElementByRef(elements, strings.TrimPrefix(ref, "@"))
+	element := findElementByRef(elements, "@"+strings.TrimPrefix(ref, "@"))
 	if element == nil {
 		return 0, 0, fmt.Errorf("ref %s not found on current screen; refs come from the latest 'dump ui'", ref)
 	}

--- a/commands/input.go
+++ b/commands/input.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/mobile-next/mobilecli/devices"
 	"github.com/mobile-next/mobilecli/devices/devicekit"
@@ -92,7 +91,7 @@ func TapCommand(req TapRequest) *CommandResponse {
 }
 
 // resolveRefTapPoint re-dumps the UI tree, numbers it exactly like "dump ui"
-// does, and returns the center of the element matching ref ("@e5" or "e5").
+// does, and returns the center of the element matching ref ("@e5").
 // Refs are positional against a fresh dump; there is no staleness tracking.
 func resolveRefTapPoint(device devices.ControllableDevice, ref string) (int, int, error) {
 	elements, err := device.DumpSource()
@@ -101,7 +100,7 @@ func resolveRefTapPoint(device devices.ControllableDevice, ref string) (int, int
 	}
 
 	types.AttachRefs(elements)
-	element := findElementByRef(elements, "@"+strings.TrimPrefix(ref, "@"))
+	element := findElementByRef(elements, ref)
 	if element == nil {
 		return 0, 0, fmt.Errorf("ref %s not found on current screen; refs come from the latest 'dump ui'", ref)
 	}

--- a/commands/input_test.go
+++ b/commands/input_test.go
@@ -17,15 +17,15 @@ func TestFindElementByRefSearchesNestedChildren(t *testing.T) {
 	}
 	types.AttachRefs(elements)
 
-	element := findElementByRef(elements, "e2")
+	element := findElementByRef(elements, "@e2")
 	if element == nil {
-		t.Fatal("expected to find e2")
+		t.Fatal("expected to find @e2")
 	}
 	if element.Type != "button" {
 		t.Fatalf("expected button, got %s", element.Type)
 	}
 
-	if findElementByRef(elements, "e99") != nil {
-		t.Fatal("expected e99 to be missing")
+	if findElementByRef(elements, "@e99") != nil {
+		t.Fatal("expected @e99 to be missing")
 	}
 }

--- a/types/screen.go
+++ b/types/screen.go
@@ -26,7 +26,7 @@ type ScreenElement struct {
 	Children    []ScreenElement   `json:"children,omitempty"`
 }
 
-// AttachRefs assigns each element a ref ("e1".."eN") in depth-first pre-order,
+// AttachRefs assigns each element a ref ("@e1".."@eN") in depth-first pre-order,
 // so a ref is the element's position in the tree as printed. Refs are only
 // valid against the dump that produced them.
 func AttachRefs(elements []ScreenElement) {
@@ -37,7 +37,7 @@ func AttachRefs(elements []ScreenElement) {
 func attachRefs(elements []ScreenElement, counter *int) {
 	for i := range elements {
 		*counter++
-		elements[i].Ref = fmt.Sprintf("e%d", *counter)
+		elements[i].Ref = fmt.Sprintf("@e%d", *counter)
 		attachRefs(elements[i].Children, counter)
 	}
 }

--- a/types/screen_test.go
+++ b/types/screen_test.go
@@ -23,7 +23,7 @@ func TestAttachRefsNumbersDepthFirstPreOrder(t *testing.T) {
 		elements[0].Children[1].Children[0].Ref,
 		elements[1].Ref,
 	}
-	want := []string{"e1", "e2", "e3", "e4", "e5"}
+	want := []string{"@e1", "@e2", "@e3", "@e4", "@e5"}
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("ref %d: got %q, want %q", i, got[i], want[i])

--- a/types/screen_text.go
+++ b/types/screen_text.go
@@ -25,7 +25,7 @@ func writeElementLines(builder *strings.Builder, elements []ScreenElement, depth
 }
 
 func formatElementLine(element ScreenElement) string {
-	parts := []string{fmt.Sprintf("@%s [%s]", element.Ref, element.Type)}
+	parts := []string{fmt.Sprintf("%s [%s]", element.Ref, element.Type)}
 
 	if description := elementDescription(element); description != "" {
 		parts = append(parts, fmt.Sprintf("%q", description))


### PR DESCRIPTION
Refs in `dump ui` JSON are now `@e1`, `@e2`, ... matching what `io tap` expects, so they can be pasted verbatim. Text output already used the `@` prefix and is unchanged.

Refs are unreleased, so no compatibility concern.

## Test plan
- [x] `go test ./types ./commands`
- [x] `dump ui` on Pixel_9_Pro emulator shows `@eN` refs
- [x] `io tap @e50` resolves and taps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Element references now consistently use the `@eN` format.
  - Reference lookup requires the `@` prefix and preserves the provided reference format.
  - Screen output displays references directly before the element type without adding an extra prefix.
  - Updated nested lookup behavior and reference display expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->