### PR TITLE
fix: resolve noctx and staticcheck lint findings

### DIFF
--- a/devices/android_flutter.go
+++ b/devices/android_flutter.go
@@ -582,7 +582,7 @@ func (vm *flutterVM) offsetZeroID(offsetClassID string) (string, error) {
 			return id, nil
 		}
 	}
-	return "", fmt.Errorf("Offset.zero not found among live instances")
+	return "", fmt.Errorf("offset.zero not found among live instances")
 }
 
 // visit walks a render object subtree, returning the meaningful ScreenElements

--- a/devices/android_rpc.go
+++ b/devices/android_rpc.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -44,11 +45,7 @@ func agentRequestWithTimeout(port int, method string, params map[string]any, tim
 	}()
 
 	client := &http.Client{Timeout: timeout}
-	resp, err := client.Post(
-		fmt.Sprintf("http://localhost:%d/", port),
-		"application/json",
-		bytes.NewReader(payload),
-	)
+	resp, err := postJSON(client, port, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("connect to agent on port %d: %w", port, err)
 	}
@@ -78,10 +75,19 @@ func agentRequestWithTimeout(port int, method string, params map[string]any, tim
 // isAgentReady checks whether the agent socket is already accepting connections.
 func isAgentReady(port int) bool {
 	client := &http.Client{Timeout: 300 * time.Millisecond}
-	resp, err := client.Post(fmt.Sprintf("http://localhost:%d/", port), "application/json", bytes.NewReader([]byte("{}")))
+	resp, err := postJSON(client, port, bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return false
 	}
 	resp.Body.Close()
 	return true
+}
+
+func postJSON(client *http.Client, port int, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, fmt.Sprintf("http://localhost:%d/", port), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return client.Do(req)
 }

--- a/devices/ios/debugserver/gdbserver.go
+++ b/devices/ios/debugserver/gdbserver.go
@@ -78,7 +78,7 @@ func (g *GDBServer) formatPacket(pck string) string {
 }
 
 func (g *GDBServer) Recv() (string, error) {
-	if g.scanner.Scan() == false {
+	if !g.scanner.Scan() {
 		return "", g.scanner.Err()
 	}
 	return g.scanner.Text(), nil

--- a/devices/remote.go
+++ b/devices/remote.go
@@ -299,7 +299,7 @@ func uploadFileToURL(filePath, uploadURL string) error {
 
 	start := time.Now()
 
-	req, err := http.NewRequest(http.MethodPut, u.String(), f)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, u.String(), f)
 	if err != nil {
 		return fmt.Errorf("failed to create upload request: %w", err)
 	}
@@ -323,6 +323,14 @@ func uploadFileToURL(filePath, uploadURL string) error {
 	return nil
 }
 
+func httpGet(u string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
 func downloadFile(downloadURL, outputPath string, cb *ScreenRecordCallbacks) error {
 	parsed, err := url.Parse(downloadURL)
 	if err != nil {
@@ -334,7 +342,7 @@ func downloadFile(downloadURL, outputPath string, cb *ScreenRecordCallbacks) err
 	}
 
 	utils.Verbose("downloading from %v", parsed)
-	resp, err := http.Get(parsed.String())
+	resp, err := httpGet(parsed.String())
 	if err != nil {
 		return fmt.Errorf("HTTP GET failed: %w", err)
 	}

--- a/rpc/rest.go
+++ b/rpc/rest.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -56,7 +57,7 @@ func RESTCall(token, method, path string, body any, result any) error {
 		reqBody = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequest(method, base+path, reqBody)
+	req, err := http.NewRequestWithContext(context.Background(), method, base+path, reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)
 	}


### PR DESCRIPTION
- Use http.NewRequestWithContext for all outgoing HTTP requests (android agent RPC, remote upload/download, fleet REST)
- Simplify bool comparison in gdbserver Recv
- Lowercase error string in android_flutter

noctx and staticcheck are now clean in make lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Added context support to device, upload, download, and REST requests.
  - Centralized request handling while preserving existing headers, validation, error handling, and progress reporting.
- **Bug Fixes**
  - Corrected the `offset.zero` error message casing.
- **Maintenance**
  - Simplified internal scanning logic without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->