### PR TITLE
fix: resolve funlen, unused and unconvert lint findings

### DIFF
--- a/devices/android_flutter.go
+++ b/devices/android_flutter.go
@@ -429,8 +429,6 @@ func (vm *flutterVM) disposeSemantics(handleID string) {
 	_, _ = vm.invoke(handleID, "dispose", nil)
 }
 
-var offsetSizePattern = regexp.MustCompile(`\(([-\d.]+),\s*([-\d.]+)\)`)
-
 func (vm *flutterVM) dumpRenderTree(dpr float64) ([]types.ScreenElement, error) {
 	vm.dpr = dpr
 	t0 := time.Now()

--- a/devices/android_fs_test.go
+++ b/devices/android_fs_test.go
@@ -2,7 +2,7 @@ package devices
 
 import "testing"
 
-func Test_androidParseLsLine(t *testing.T) {
+func Test_androidParseLsLine(t *testing.T) { //nolint:funlen
 	tests := []struct {
 		name     string
 		line     string

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -301,10 +301,6 @@ func (d *IOSDevice) StartTunnelWithCallback(onProcessDied func(error)) error {
 	return d.tunnelManager.StartTunnelWithCallback(onProcessDied)
 }
 
-func (d *IOSDevice) stopTunnel() error {
-	return d.tunnelManager.StopTunnel()
-}
-
 // Cleanup gracefully cleans up all device resources
 func (d *IOSDevice) Cleanup() error {
 	if !d.hasResourcesToCleanup() {

--- a/pkg/avc2mp4/mp4writer.go
+++ b/pkg/avc2mp4/mp4writer.go
@@ -110,7 +110,7 @@ func writeMp4(units []accessUnit, output io.WriteSeeker) error {
 		ptsMs := (au.timestampUs - firstTs) / 1000
 		dtsMs := ptsMs // baseline profile, no B-frames
 
-		err := muxer.Write(trackID, annexB, uint64(ptsMs), uint64(dtsMs))
+		err := muxer.Write(trackID, annexB, ptsMs, dtsMs)
 		if err != nil {
 			return fmt.Errorf("writing frame: %w", err)
 		}


### PR DESCRIPTION
- Drop unnecessary uint64 conversions in mp4writer (timestampUs is already uint64)
- Remove unused offsetSizePattern regex and IOSDevice.stopTunnel
- Mark table-driven Test_androidParseLsLine with //nolint:funlen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal device and rendering helpers.
  * Simplified MP4 frame timestamp handling without changing error behavior.

* **Tests**
  * Updated lint handling for an existing Android device parsing test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->