### PR TITLE
feat: add --full flag to dump ui to include the on-screen keyboard

### DIFF
--- a/agents/android/java/DeviceServer.java
+++ b/agents/android/java/DeviceServer.java
@@ -57,7 +57,7 @@ public class DeviceServer {
 			case "device.version":
 				return new JSONObject().put("dexSha256", DEX_SHA256);
 			case "device.dump.ui":
-				return UiTreeSerializer.dump(automation, p.optLong("waitUntilIdle", 0));
+				return UiTreeSerializer.dump(automation, p.optLong("waitUntilIdle", 0), p.optBoolean("full", false));
 			case "device.screenshot":
 				return screenshot(automation, p);
 			case "device.io.keyboard.hide":

--- a/agents/android/java/UiTreeSerializer.java
+++ b/agents/android/java/UiTreeSerializer.java
@@ -23,7 +23,7 @@ class UiTreeSerializer {
 	private static final long IDLE_WINDOW_MS = 500;
 
 	@SuppressWarnings("deprecation") // recycle() is a no-op on API 33+, still frees pools below
-	static JSONObject dump(UiAutomation automation, long waitUntilIdle) throws Exception {
+	static JSONObject dump(UiAutomation automation, long waitUntilIdle, boolean full) throws Exception {
 		if (waitUntilIdle > 0) {
 			// Best-effort settle: waitForIdle throws when the UI never goes idle
 			// (animations, video, spinners). Dump the current state regardless.
@@ -36,6 +36,11 @@ class UiTreeSerializer {
 
 		List<AccessibilityNodeInfo> roots = new ArrayList<>();
 		for (AccessibilityWindowInfo window : automation.getWindows()) {
+			// The soft keyboard is noise for most callers: skip IME windows unless asked for a full dump.
+			if (!full && window.getType() == AccessibilityWindowInfo.TYPE_INPUT_METHOD) {
+				window.recycle();
+				continue;
+			}
 			AccessibilityNodeInfo root = window.getRoot();
 			if (root != null) roots.add(root);
 			window.recycle();

--- a/cli/dump.go
+++ b/cli/dump.go
@@ -14,7 +14,10 @@ var dumpCmd = &cobra.Command{
 	Long:  `Perform dump operations like UI tree extraction from devices.`,
 }
 
-var dumpUIFormat string
+var (
+	dumpUIFormat string
+	dumpUIFull   bool
+)
 
 var dumpUICmd = &cobra.Command{
 	Use:   "ui",
@@ -24,6 +27,7 @@ var dumpUICmd = &cobra.Command{
 		req := commands.DumpUIRequest{
 			DeviceID: deviceId,
 			Format:   dumpUIFormat,
+			Full:     dumpUIFull,
 		}
 
 		raw, err := callDaemon("cli.dump.ui", req, daemon.NoTimeout)
@@ -58,4 +62,5 @@ func init() {
 	// dump ui command flags
 	dumpUICmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to dump UI tree from")
 	dumpUICmd.Flags().StringVar(&dumpUIFormat, "format", "", "Output format: 'text' for indented element lines, 'raw' for unprocessed tree from agent (Default: json)")
+	dumpUICmd.Flags().BoolVar(&dumpUIFull, "full", false, "Include additional elements normally left out, such as the on-screen keyboard")
 }

--- a/commands/dump.go
+++ b/commands/dump.go
@@ -9,9 +9,11 @@ import (
 // DumpUIRequest represents the parameters for dumping UI tree.
 // Format is "json" (default), "text" for indented one-line-per-element output,
 // or "raw" for the unprocessed agent tree.
+// Full includes elements normally left out, such as the on-screen keyboard.
 type DumpUIRequest struct {
 	DeviceID string `json:"deviceId"`
 	Format   string `json:"format"`
+	Full     bool   `json:"full"`
 }
 
 // DumpUIResponse represents the response for a dump UI command
@@ -38,10 +40,11 @@ func DumpUICommand(req DumpUIRequest) *CommandResponse {
 	}
 
 	var response DumpUIResponse
+	opts := devices.DumpOptions{Full: req.Full}
 
 	// Check if raw format is requested
 	if req.Format == "raw" {
-		rawData, err := targetDevice.DumpSourceRaw()
+		rawData, err := targetDevice.DumpSourceRaw(opts)
 		if err != nil {
 			return NewErrorResponse(fmt.Errorf("failed to dump raw UI from device %s: %w", targetDevice.ID(), err))
 		}
@@ -51,7 +54,7 @@ func DumpUICommand(req DumpUIRequest) *CommandResponse {
 		}
 	} else {
 		// Dump UI tree from the device
-		elements, err := targetDevice.DumpSource()
+		elements, err := targetDevice.DumpSource(opts)
 		if err != nil {
 			return NewErrorResponse(fmt.Errorf("failed to dump UI from device %s: %w", targetDevice.ID(), err))
 		}

--- a/commands/input.go
+++ b/commands/input.go
@@ -94,7 +94,7 @@ func TapCommand(req TapRequest) *CommandResponse {
 // does, and returns the center of the element matching ref ("@e5").
 // Refs are positional against a fresh dump; there is no staleness tracking.
 func resolveRefTapPoint(device devices.ControllableDevice, ref string) (int, int, error) {
-	elements, err := device.DumpSource()
+	elements, err := device.DumpSource(devices.DumpOptions{})
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to dump UI to resolve ref %s: %w", ref, err)
 	}

--- a/devices/android.go
+++ b/devices/android.go
@@ -1575,8 +1575,8 @@ func collectUiNodeElements(nodes []uiNode) []types.ScreenElement {
 	return elements
 }
 
-func (d *AndroidDevice) getDeviceServerDump() (string, error) {
-	nodes, err := d.dumpUiNodes()
+func (d *AndroidDevice) getDeviceServerDump(opts DumpOptions) (string, error) {
+	nodes, err := d.dumpUiNodes(opts)
 	if err != nil {
 		return "", err
 	}
@@ -1615,8 +1615,8 @@ func (d *AndroidDevice) getUiAutomatorDump() (string, error) {
 	return "", fmt.Errorf("failed to get UIAutomator XML after 10 tries")
 }
 
-func (d *AndroidDevice) DumpSourceRaw() (any, error) {
-	if jsonStr, err := d.getDeviceServerDump(); err == nil {
+func (d *AndroidDevice) DumpSourceRaw(opts DumpOptions) (any, error) {
+	if jsonStr, err := d.getDeviceServerDump(opts); err == nil {
 		return jsonStr, nil
 	} else {
 		utils.Verbose("device server dump unavailable, falling back to uiautomator: %v", err)
@@ -1630,7 +1630,7 @@ func (d *AndroidDevice) DumpSourceRaw() (any, error) {
 	return xmlContent, nil
 }
 
-func (d *AndroidDevice) DumpSource() ([]ScreenElement, error) {
+func (d *AndroidDevice) DumpSource(opts DumpOptions) ([]ScreenElement, error) {
 	// Flutter apps render into an opaque native view, so the accessibility-based
 	// dumps below miss typed/unlabeled/non-semantic widgets. When the foreground
 	// app is a debuggable Flutter app, read its live render tree from the Dart VM
@@ -1639,7 +1639,7 @@ func (d *AndroidDevice) DumpSource() ([]ScreenElement, error) {
 		return elements, nil
 	}
 
-	if nodes, err := d.dumpUiNodes(); err == nil {
+	if nodes, err := d.dumpUiNodes(opts); err == nil {
 		return collectUiNodeElements(nodes), nil
 	} else {
 		utils.Verbose("device server dump unavailable, falling back to uiautomator: %v", err)

--- a/devices/android_device_server.go
+++ b/devices/android_device_server.go
@@ -131,10 +131,10 @@ func (d *AndroidDevice) serverRequest(method string, params map[string]any) (jso
 
 // dumpUiNodes fetches the UI hierarchy from the DeviceServer. Callers fall back
 // to uiautomator when it's unavailable.
-func (d *AndroidDevice) dumpUiNodes() ([]uiNode, error) {
+func (d *AndroidDevice) dumpUiNodes(opts DumpOptions) ([]uiNode, error) {
 	startTime := time.Now()
 
-	raw, err := d.serverRequest("device.dump.ui", map[string]any{"waitUntilIdle": dumpUiWaitUntilIdleMs})
+	raw, err := d.serverRequest("device.dump.ui", map[string]any{"waitUntilIdle": dumpUiWaitUntilIdleMs, "full": opts.Full})
 	if err != nil {
 		return nil, fmt.Errorf("device server dump.ui: %w", err)
 	}

--- a/devices/common.go
+++ b/devices/common.go
@@ -149,6 +149,12 @@ type LaunchOptions struct {
 	Activity string
 }
 
+// DumpOptions controls what a UI dump includes.
+type DumpOptions struct {
+	// Full includes windows normally left out, such as the on-screen keyboard.
+	Full bool
+}
+
 type ControllableDevice interface {
 	ID() string
 	Name() string
@@ -181,8 +187,8 @@ type ControllableDevice interface {
 	ClearApp(bundleID string) error
 	Info() (*FullDeviceInfo, error)
 	StartScreenCapture(config ScreenCaptureConfig) error
-	DumpSource() ([]ScreenElement, error)
-	DumpSourceRaw() (any, error)
+	DumpSource(opts DumpOptions) ([]ScreenElement, error)
+	DumpSourceRaw(opts DumpOptions) (any, error)
 	GetOrientation() (string, error)
 	SetOrientation(orientation string) error
 	ListCrashReports() ([]CrashReport, error)

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -1164,7 +1164,7 @@ func (d *IOSDevice) StartScreenCapture(config ScreenCaptureConfig) error {
 	return d.mjpegClient.StartScreenCapture(config.Format, config.OnData)
 }
 
-func (d *IOSDevice) DumpSource() ([]ScreenElement, error) {
+func (d *IOSDevice) DumpSource(_ DumpOptions) ([]ScreenElement, error) {
 	// Flutter apps render into an opaque native view, so the accessibility dump
 	// misses typed/unlabeled/non-semantic widgets. When the foreground app is a
 	// Flutter app with a live Dart VM service, read its render tree instead. Any
@@ -1175,7 +1175,7 @@ func (d *IOSDevice) DumpSource() ([]ScreenElement, error) {
 	return d.deviceKitClient.GetSourceElements()
 }
 
-func (d *IOSDevice) DumpSourceRaw() (any, error) {
+func (d *IOSDevice) DumpSourceRaw(_ DumpOptions) (any, error) {
 	return d.deviceKitClient.GetSourceRaw()
 }
 
@@ -1283,7 +1283,7 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 			}
 			return fmt.Errorf("timeout waiting for BroadcastUploadExtension button to appear, last element dump: %s", dump)
 		case <-ticker.C:
-			elements, err := d.DumpSource()
+			elements, err := d.DumpSource(DumpOptions{})
 			if err != nil {
 				// continue trying on error
 				continue
@@ -1346,7 +1346,7 @@ func (d *IOSDevice) clickStartBroadcastButton() error {
 			}
 			return fmt.Errorf("timeout waiting for Start Broadcast button to appear, last element dump: %s", dump)
 		case <-ticker.C:
-			elements, err := d.DumpSource()
+			elements, err := d.DumpSource(DumpOptions{})
 			if err != nil {
 				// continue trying on error
 				continue

--- a/devices/remote.go
+++ b/devices/remote.go
@@ -241,20 +241,20 @@ func (r *RemoteDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 	return rpcCall[*ForegroundAppInfo](r, "device.apps.foreground", params{})
 }
 
-func (r *RemoteDevice) DumpSource() ([]ScreenElement, error) {
+func (r *RemoteDevice) DumpSource(opts DumpOptions) ([]ScreenElement, error) {
 	resp, err := rpcCall[struct {
 		Elements []ScreenElement `json:"elements"`
-	}](r, "device.dump.ui", params{})
+	}](r, "device.dump.ui", params{"full": opts.Full})
 	if err != nil {
 		return nil, err
 	}
 	return resp.Elements, nil
 }
 
-func (r *RemoteDevice) DumpSourceRaw() (any, error) {
+func (r *RemoteDevice) DumpSourceRaw(opts DumpOptions) (any, error) {
 	resp, err := rpcCall[struct {
 		RawData any `json:"rawData"`
-	}](r, "device.dump.ui", params{"format": "raw"})
+	}](r, "device.dump.ui", params{"format": "raw", "full": opts.Full})
 	if err != nil {
 		return nil, err
 	}

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -896,7 +896,7 @@ func (s *SimulatorDevice) getDeviceKitEnvPort(envVar string) (int, error) {
 	return port, nil
 }
 
-func (s SimulatorDevice) DumpSource() ([]ScreenElement, error) {
+func (s SimulatorDevice) DumpSource(_ DumpOptions) ([]ScreenElement, error) {
 	// Flutter apps render into an opaque native view, so the accessibility dump
 	// misses typed/unlabeled/non-semantic widgets. When the foreground app is a
 	// Flutter app with a live Dart VM service, read its render tree instead. Any
@@ -907,7 +907,7 @@ func (s SimulatorDevice) DumpSource() ([]ScreenElement, error) {
 	return s.deviceKitClient.GetSourceElements()
 }
 
-func (s SimulatorDevice) DumpSourceRaw() (any, error) {
+func (s SimulatorDevice) DumpSourceRaw(_ DumpOptions) (any, error) {
 	return s.deviceKitClient.GetSourceRaw()
 }
 

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -777,6 +777,15 @@
             ],
             "default": "json"
           }
+        },
+        {
+          "name": "full",
+          "description": "Include additional elements normally left out, such as the on-screen keyboard",
+          "required": false,
+          "schema": {
+            "type": "boolean",
+            "default": false
+          }
         }
       ],
       "result": {

--- a/docs/openrpc.md
+++ b/docs/openrpc.md
@@ -518,6 +518,7 @@ Dumps the UI hierarchy of the device screen
 |------|------|----------|-------------|
 | `deviceId` | `string` | ✓ | ID of the target device |
 | `format` | enum: `json, raw` |  | Output format (json or raw) |
+| `full` | `boolean` |  | Include additional elements normally left out, such as the on-screen keyboard |
 
 #### Response
 

--- a/server/server.go
+++ b/server/server.go
@@ -710,6 +710,7 @@ type DeviceRebootParams struct {
 type DumpUIParams struct {
 	DeviceID string `json:"deviceId"`
 	Format   string `json:"format,omitempty"` // "json" or "raw"
+	Full     bool   `json:"full,omitempty"`   // include the on-screen keyboard and other normally hidden windows
 }
 
 type AppsLaunchParams struct {
@@ -1052,6 +1053,7 @@ func handleDumpUI(params json.RawMessage) (any, error) {
 	req := commands.DumpUIRequest{
 		DeviceID: dumpUIParams.DeviceID,
 		Format:   dumpUIParams.Format,
+		Full:     dumpUIParams.Full,
 	}
 
 	response := commands.DumpUICommand(req)

--- a/skills/mobilecli/reference.md
+++ b/skills/mobilecli/reference.md
@@ -127,6 +127,9 @@ All commands support the global `--device <id>` flag to specify the target devic
 
   # Raw XML/JSON source from agent
   mobilecli dump ui --device <device-id> --format raw
+
+  # Include elements normally left out, such as the on-screen keyboard (Android)
+  mobilecli dump ui --device <device-id> --full
   ```
 * **List Webviews**:
   ```bash


### PR DESCRIPTION
## Summary

Adds a `--full` flag to `mobilecli dump ui` (and a `full` param to the `device.dump.ui` RPC). By default the Android agent now skips input-method windows, so the soft keyboard no longer clutters dumps. Pass `--full` to get it back.

## Changes

- **Android agent**: `UiTreeSerializer.dump` skips `TYPE_INPUT_METHOD` windows unless `full` is set.
- **Devices**: new `DumpOptions{Full}` struct; `DumpSource`/`DumpSourceRaw` take it. Android and remote forward it; iOS and simulator ignore it.
- **CLI / server / commands**: `--full` flag and `full` JSON field plumbed through `cli.dump.ui` and `device.dump.ui`.
- **Docs**: openrpc.json, openrpc.md, and the mobilecli skill reference.

## Testing

`go build ./...` and `go vet` pass. Needs a manual check on an Android device with the keyboard open: `dump ui` should omit it, `dump ui --full` should include it.

## Related Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--full` option to UI dumps.
  * Full UI dumps can now include the on-screen keyboard and other normally hidden windows.
  * The option is supported for raw and structured dumps across supported device connections.

* **Bug Fixes**
  * Standard UI dumps now omit soft-keyboard windows by default for a cleaner hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->