### PR TITLE
feat: browser OAuth login, device code only when headless

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -66,7 +68,7 @@ var authCmd = &cobra.Command{
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Log in to your account",
-	Long:  `Authenticates using a device code flow. Displays a URL and code to enter in your browser.`,
+	Long:  `Authenticates using a device code flow. Opens your browser with the code prefilled, or prints the URL and code when running over SSH, in CI, headless, or with --no-browser.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if authProvider != "mobilenext" {
 			return fmt.Errorf("unsupported provider %q, supported values: \"mobilenext\"", authProvider)
@@ -175,8 +177,17 @@ func runAuthLogin() error {
 		return err
 	}
 
-	fmt.Printf("To log in, open this URL in your browser:\n\n\t%s\n\n", codeResp.VerificationURI)
-	fmt.Printf("And enter the code: %s\n\n", codeResp.UserCode)
+	loginURL := verificationURLWithCode(codeResp.VerificationURI, codeResp.UserCode)
+	opened := false
+	if !shouldSkipBrowser(noBrowser, runtime.GOOS, os.Getenv) {
+		opened = openBrowser(loginURL) == nil
+	}
+	if opened {
+		fmt.Printf("Opened your browser to log in. If it did not open, visit:\n\n\t%s\n\n", loginURL)
+	} else {
+		fmt.Printf("To log in, open this URL in your browser:\n\n\t%s\n\n", codeResp.VerificationURI)
+	}
+	fmt.Printf("Your code: %s\n\n", codeResp.UserCode)
 	fmt.Println("Waiting for authorization...")
 
 	token, err := pollForToken(codeResp.DeviceCode, codeResp.Interval, codeResp.ExpiresIn)
@@ -237,4 +248,5 @@ func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.AddCommand(authLoginCmd, authLogoutCmd, authTokenCmd)
 	authLoginCmd.Flags().StringVar(&authProvider, "provider", "mobilenext", "authentication provider (supported values: \"mobilenext\")")
+	authLoginCmd.Flags().BoolVar(&noBrowser, "no-browser", false, "print the login URL and code instead of opening a browser")
 }

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -68,7 +68,7 @@ var authCmd = &cobra.Command{
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Log in to your account",
-	Long:  `Authenticates using a device code flow. Opens your browser with the code prefilled, or prints the URL and code when running over SSH, in CI, headless, or with --no-browser.`,
+	Long:  `Opens your browser to approve the login and pick an organization. Falls back to a device code (URL + code to type) over SSH, in CI, headless, or with --no-browser.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if authProvider != "mobilenext" {
 			return fmt.Errorf("unsupported provider %q, supported values: \"mobilenext\"", authProvider)
@@ -172,25 +172,13 @@ func pollForToken(deviceCode string, interval, expiresIn int) (string, error) {
 }
 
 func runAuthLogin() error {
-	codeResp, err := requestDeviceCode()
-	if err != nil {
-		return err
-	}
-
-	loginURL := verificationURLWithCode(codeResp.VerificationURI, codeResp.UserCode)
-	opened := false
-	if !shouldSkipBrowser(noBrowser, runtime.GOOS, os.Getenv) {
-		opened = openBrowser(loginURL) == nil
-	}
-	if opened {
-		fmt.Printf("Opened your browser to log in. If it did not open, visit:\n\n\t%s\n\n", loginURL)
+	var token string
+	var err error
+	if shouldSkipBrowser(noBrowser, runtime.GOOS, os.Getenv) {
+		token, err = runDeviceCodeLogin()
 	} else {
-		fmt.Printf("To log in, open this URL in your browser:\n\n\t%s\n\n", codeResp.VerificationURI)
+		token, err = runOAuthLogin(oauthAuthorizeURL, oauthTokenURL)
 	}
-	fmt.Printf("Your code: %s\n\n", codeResp.UserCode)
-	fmt.Println("Waiting for authorization...")
-
-	token, err := pollForToken(codeResp.DeviceCode, codeResp.Interval, codeResp.ExpiresIn)
 	if err != nil {
 		return err
 	}
@@ -203,6 +191,19 @@ func runAuthLogin() error {
 
 	fmt.Println("Successfully logged in")
 	return nil
+}
+
+func runDeviceCodeLogin() (string, error) {
+	codeResp, err := requestDeviceCode()
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Printf("To log in, open this URL in your browser:\n\n\t%s\n\n", codeResp.VerificationURI)
+	fmt.Printf("Your code: %s\n\n", codeResp.UserCode)
+	fmt.Println("Waiting for authorization...")
+
+	return pollForToken(codeResp.DeviceCode, codeResp.Interval, codeResp.ExpiresIn)
 }
 
 var authLogoutCmd = &cobra.Command{

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -24,7 +24,7 @@ const (
 
 	deviceFlowClientID = "ed38b523-56e8-4719-837b-7074fac152b5"
 	deviceCodeURL      = "https://app.mobilenext.ai/login/device/code"
-	deviceTokenURL     = "https://app.mobilenext.ai/login/device/token"
+	deviceTokenURL     = "https://app.mobilenext.ai/login/device/token" // #nosec G101 -- public endpoint URL, not a credential
 	deviceGrantType    = "urn:ietf:params:oauth:grant-type:device_code"
 
 	authHTTPTimeout = 30 * time.Second
@@ -91,12 +91,20 @@ func postJSON(url string, body []byte) (*http.Response, error) {
 }
 
 func requestDeviceCode() (*deviceCodeResponse, error) {
-	reqBody, _ := json.Marshal(deviceCodeRequest{ClientID: deviceFlowClientID})
+	reqBody, err := json.Marshal(deviceCodeRequest{ClientID: deviceFlowClientID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build device code request: %w", err)
+	}
+
 	resp, err := postJSON(deviceCodeURL, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request device code: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			utils.Verbose("failed to close device code response: %v", closeErr)
+		}
+	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -129,18 +137,24 @@ func pollForToken(deviceCode string, interval, expiresIn int) (string, error) {
 	for time.Now().Before(deadline) {
 		time.Sleep(pollInterval)
 
-		reqBody, _ := json.Marshal(deviceTokenRequest{
+		reqBody, err := json.Marshal(deviceTokenRequest{
 			ClientID:   deviceFlowClientID,
 			DeviceCode: deviceCode,
 			GrantType:  deviceGrantType,
 		})
+		if err != nil {
+			return "", fmt.Errorf("failed to build token request: %w", err)
+		}
+
 		resp, err := postJSON(deviceTokenURL, reqBody)
 		if err != nil {
 			return "", fmt.Errorf("failed to poll for token: %w", err)
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			utils.Verbose("failed to close token response: %v", closeErr)
+		}
 		if err != nil {
 			return "", fmt.Errorf("failed to read response: %w", err)
 		}

--- a/cli/auth_browser.go
+++ b/cli/auth_browser.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+	"runtime"
+)
+
+var noBrowser bool
+
+// shouldSkipBrowser reports whether login must fall back to printing the
+// device code instead of opening a browser: explicit --no-browser, an SSH
+// session, CI, or a Linux box with no display.
+func shouldSkipBrowser(noBrowserFlag bool, goos string, getenv func(string) string) bool {
+	if noBrowserFlag {
+		return true
+	}
+	if getenv("SSH_CONNECTION") != "" || getenv("SSH_TTY") != "" {
+		return true
+	}
+	if getenv("CI") != "" {
+		return true
+	}
+	// ponytail: macOS/Windows always have a display; only Linux/BSD can be headless
+	if goos != "darwin" && goos != "windows" && getenv("DISPLAY") == "" && getenv("WAYLAND_DISPLAY") == "" {
+		return true
+	}
+	return false
+}
+
+// verificationURLWithCode appends user_code so the login page can prefill it.
+func verificationURLWithCode(verificationURI, userCode string) string {
+	u, err := url.Parse(verificationURI)
+	if err != nil {
+		return verificationURI
+	}
+	q := u.Query()
+	q.Set("user_code", userCode)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func openBrowser(target string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to open browser: %w", err)
+	}
+	return nil
+}

--- a/cli/auth_browser.go
+++ b/cli/auth_browser.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+
+	"github.com/mobile-next/mobilecli/utils"
 )
 
 var noBrowser bool
@@ -42,6 +44,11 @@ func openBrowser(target string) error {
 		return fmt.Errorf("failed to open browser: %w", err)
 	}
 	// ponytail: Start, not Run. xdg-open can block until the browser exits on some desktops.
-	go func() { _ = cmd.Wait() }()
+	// Wait only reaps the child; the browser opening is what mattered and already happened.
+	go func() {
+		if waitErr := cmd.Wait(); waitErr != nil {
+			utils.Verbose("browser opener exited: %v", waitErr)
+		}
+	}()
 	return nil
 }

--- a/cli/auth_browser.go
+++ b/cli/auth_browser.go
@@ -41,5 +41,7 @@ func openBrowser(target string) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to open browser: %w", err)
 	}
+	// ponytail: Start, not Run. xdg-open can block until the browser exits on some desktops.
+	go func() { _ = cmd.Wait() }()
 	return nil
 }

--- a/cli/auth_browser.go
+++ b/cli/auth_browser.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"net/url"
 	"os/exec"
 	"runtime"
 )
@@ -27,18 +26,6 @@ func shouldSkipBrowser(noBrowserFlag bool, goos string, getenv func(string) stri
 		return true
 	}
 	return false
-}
-
-// verificationURLWithCode appends user_code so the login page can prefill it.
-func verificationURLWithCode(verificationURI, userCode string) string {
-	u, err := url.Parse(verificationURI)
-	if err != nil {
-		return verificationURI
-	}
-	q := u.Query()
-	q.Set("user_code", userCode)
-	u.RawQuery = q.Encode()
-	return u.String()
 }
 
 func openBrowser(target string) error {

--- a/cli/auth_browser_test.go
+++ b/cli/auth_browser_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import "testing"
+
+func envWith(vars map[string]string) func(string) string {
+	return func(k string) string { return vars[k] }
+}
+
+func TestShouldSkipBrowser(t *testing.T) {
+	cases := []struct {
+		name     string
+		flag     bool
+		goos     string
+		env      map[string]string
+		wantSkip bool
+	}{
+		{"mac desktop opens browser", false, "darwin", nil, false},
+		{"windows desktop opens browser", false, "windows", nil, false},
+		{"linux with DISPLAY opens browser", false, "linux", map[string]string{"DISPLAY": ":0"}, false},
+		{"linux with WAYLAND_DISPLAY opens browser", false, "linux", map[string]string{"WAYLAND_DISPLAY": "wayland-0"}, false},
+		{"--no-browser flag skips", true, "darwin", nil, true},
+		{"ssh session skips", false, "darwin", map[string]string{"SSH_CONNECTION": "1.2.3.4 22"}, true},
+		{"ssh tty skips", false, "darwin", map[string]string{"SSH_TTY": "/dev/pts/0"}, true},
+		{"CI skips", false, "darwin", map[string]string{"CI": "true"}, true},
+		{"headless linux skips", false, "linux", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldSkipBrowser(tc.flag, tc.goos, envWith(tc.env)); got != tc.wantSkip {
+				t.Fatalf("got %v, want %v", got, tc.wantSkip)
+			}
+		})
+	}
+}
+
+func TestVerificationURLWithCode(t *testing.T) {
+	got := verificationURLWithCode("https://app.mobilenext.ai/login/device", "ABCD-1234")
+	want := "https://app.mobilenext.ai/login/device?user_code=ABCD-1234"
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}

--- a/cli/auth_browser_test.go
+++ b/cli/auth_browser_test.go
@@ -32,11 +32,3 @@ func TestShouldSkipBrowser(t *testing.T) {
 		})
 	}
 }
-
-func TestVerificationURLWithCode(t *testing.T) {
-	got := verificationURLWithCode("https://app.mobilenext.ai/login/device", "ABCD-1234")
-	want := "https://app.mobilenext.ai/login/device?user_code=ABCD-1234"
-	if got != want {
-		t.Fatalf("got %s, want %s", got, want)
-	}
-}

--- a/cli/auth_oauth.go
+++ b/cli/auth_oauth.go
@@ -24,6 +24,7 @@ import (
 const (
 	oauthClientID     = "mobilecli"
 	oauthAuthorizeURL = "https://app.mobilenext.ai/login/oauth/authorize"
+	// #nosec G101 -- this is the public token endpoint URL, not a credential
 	oauthTokenURL     = "https://app.mobilenext.ai/login/oauth/token"
 	oauthCallbackPath = "/callback"
 	// Longer than the server's 10-minute consent session: the CLI must still be listening for
@@ -92,10 +93,14 @@ func waitForCallback(ctx context.Context, listener net.Listener) (oauthCallback,
 		q := r.URL.Query()
 		cb := oauthCallback{code: q.Get("code"), state: q.Get("state"), err: q.Get("error")}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		page := "<h2>Logged in to mobilecli</h2><p>You can close this tab.</p>"
 		if cb.err != "" || cb.code == "" {
-			fmt.Fprint(w, "<h2>Login failed</h2><p>You can close this tab and retry in the terminal.</p>")
-		} else {
-			fmt.Fprint(w, "<h2>Logged in to mobilecli</h2><p>You can close this tab.</p>")
+			page = "<h2>Login failed</h2><p>You can close this tab and retry in the terminal.</p>"
+		}
+		// the login itself already succeeded or failed by now, so a browser that
+		// hung up before reading the page changes nothing
+		if _, writeErr := fmt.Fprint(w, page); writeErr != nil {
+			utils.Verbose("failed to write callback page: %v", writeErr)
 		}
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
@@ -105,13 +110,19 @@ func waitForCallback(ctx context.Context, listener net.Listener) (oauthCallback,
 		default:
 		}
 	})
-	go func() { _ = server.Serve(listener) }()
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			utils.Verbose("callback listener stopped: %v", serveErr)
+		}
+	}()
 	// Shutdown, not Close: it waits for the in-flight handler to finish writing the page, so the
 	// browser never sees the connection drop mid-response.
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
+		if shutdownErr := server.Shutdown(shutdownCtx); shutdownErr != nil {
+			utils.Verbose("callback listener shutdown: %v", shutdownErr)
+		}
 	}()
 
 	select {
@@ -140,7 +151,11 @@ func exchangeCode(tokenURL, code, verifier, redirectURI string) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("failed to exchange code: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			utils.Verbose("failed to close token response: %v", closeErr)
+		}
+	}()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read token response: %w", err)
@@ -170,8 +185,16 @@ func runOAuthLogin(authorizeURL, tokenURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to listen for browser callback: %w", err)
 	}
-	defer listener.Close()
-	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", listener.Addr().(*net.TCPAddr).Port, oauthCallbackPath)
+	defer func() {
+		if closeErr := listener.Close(); closeErr != nil {
+			utils.Verbose("failed to close callback listener: %v", closeErr)
+		}
+	}()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return "", fmt.Errorf("callback listener is not tcp: %T", listener.Addr())
+	}
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", addr.Port, oauthCallbackPath)
 
 	loginURL := buildAuthorizeURL(authorizeURL, redirectURI, pkceChallenge(verifier), state, detectAgent(os.Getenv))
 	// A missing xdg-open (minimal Linux, WSL) is not fatal: the loopback callback works just as
@@ -194,6 +217,9 @@ func runOAuthLogin(authorizeURL, tokenURL string) (string, error) {
 	}
 	if cb.state != state {
 		return "", errors.New("login callback state mismatch")
+	}
+	if cb.code == "" {
+		return "", errors.New("login callback carried no authorization code, run `mobilecli auth login` again")
 	}
 	return exchangeCode(tokenURL, cb.code, verifier, redirectURI)
 }

--- a/cli/auth_oauth.go
+++ b/cli/auth_oauth.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/mobile-next/mobilecli/utils"
+)
+
+// OAuth authorization code + PKCE against the server's built-in "mobilecli" client
+// (RFC 8252 native app: ephemeral loopback port, no client secret).
+const (
+	oauthClientID     = "mobilecli"
+	oauthAuthorizeURL = "https://app.mobilenext.ai/login/oauth/authorize"
+	oauthTokenURL     = "https://app.mobilenext.ai/login/oauth/token"
+	oauthCallbackPath = "/callback"
+	oauthLoginTimeout = 5 * time.Minute
+)
+
+type oauthCallback struct {
+	code  string
+	state string
+	err   string
+}
+
+type oauthTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	Error       string `json:"error,omitempty"`
+}
+
+func randomURLSafe(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// pkceChallenge is S256 per RFC 7636 §4.2.
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func buildAuthorizeURL(authorizeURL, redirectURI, challenge, state string) string {
+	q := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {oauthClientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {state},
+	}
+	return authorizeURL + "?" + q.Encode()
+}
+
+// waitForCallback serves one request on listener and returns what the browser brought back.
+func waitForCallback(ctx context.Context, listener net.Listener) (oauthCallback, error) {
+	got := make(chan oauthCallback, 1)
+	server := &http.Server{ReadHeaderTimeout: 10 * time.Second}
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != oauthCallbackPath {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		cb := oauthCallback{code: q.Get("code"), state: q.Get("state"), err: q.Get("error")}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if cb.err != "" || cb.code == "" {
+			fmt.Fprint(w, "<h2>Login failed</h2><p>You can close this tab and retry in the terminal.</p>")
+		} else {
+			fmt.Fprint(w, "<h2>Logged in to mobilecli</h2><p>You can close this tab.</p>")
+		}
+		select {
+		case got <- cb:
+		default:
+		}
+	})
+	go func() { _ = server.Serve(listener) }()
+	defer server.Close()
+
+	select {
+	case cb := <-got:
+		return cb, nil
+	case <-ctx.Done():
+		return oauthCallback{}, errors.New("timed out waiting for browser login")
+	}
+}
+
+func exchangeCode(tokenURL, code, verifier, redirectURI string) (string, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {oauthClientID},
+		"code_verifier": {verifier},
+		"redirect_uri":  {redirectURI},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", utils.UserAgent())
+	resp, err := authHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to exchange code: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read token response: %w", err)
+	}
+	var tok oauthTokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+	if tok.Error != "" || tok.AccessToken == "" {
+		return "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+	return tok.AccessToken, nil
+}
+
+// runOAuthLogin opens the browser to the consent screen (pick organization, approve) and
+// receives the code on a loopback port. Returns the access token.
+func runOAuthLogin(authorizeURL, tokenURL string) (string, error) {
+	verifier, err := randomURLSafe(32)
+	if err != nil {
+		return "", err
+	}
+	state, err := randomURLSafe(16)
+	if err != nil {
+		return "", err
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("failed to listen for browser callback: %w", err)
+	}
+	defer listener.Close()
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", listener.Addr().(*net.TCPAddr).Port, oauthCallbackPath)
+
+	loginURL := buildAuthorizeURL(authorizeURL, redirectURI, pkceChallenge(verifier), state)
+	if err := openBrowser(loginURL); err != nil {
+		return "", err
+	}
+	fmt.Printf("Opened your browser to log in. If it did not open, visit:\n\n\t%s\n\n", loginURL)
+	fmt.Println("Waiting for authorization...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), oauthLoginTimeout)
+	defer cancel()
+	cb, err := waitForCallback(ctx, listener)
+	if err != nil {
+		return "", err
+	}
+	if cb.err != "" {
+		return "", fmt.Errorf("login denied: %s", cb.err)
+	}
+	if cb.state != state {
+		return "", errors.New("login callback state mismatch")
+	}
+	return exchangeCode(tokenURL, cb.code, verifier, redirectURI)
+}

--- a/cli/auth_oauth.go
+++ b/cli/auth_oauth.go
@@ -26,7 +26,9 @@ const (
 	oauthAuthorizeURL = "https://app.mobilenext.ai/login/oauth/authorize"
 	oauthTokenURL     = "https://app.mobilenext.ai/login/oauth/token"
 	oauthCallbackPath = "/callback"
-	oauthLoginTimeout = 5 * time.Minute
+	// Longer than the server's 10-minute consent session: the CLI must still be listening for
+	// as long as the browser can legitimately redirect back.
+	oauthLoginTimeout = 15 * time.Minute
 )
 
 type oauthCallback struct {
@@ -95,19 +97,28 @@ func waitForCallback(ctx context.Context, listener net.Listener) (oauthCallback,
 		} else {
 			fmt.Fprint(w, "<h2>Logged in to mobilecli</h2><p>You can close this tab.</p>")
 		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
 		select {
 		case got <- cb:
 		default:
 		}
 	})
 	go func() { _ = server.Serve(listener) }()
-	defer server.Close()
+	// Shutdown, not Close: it waits for the in-flight handler to finish writing the page, so the
+	// browser never sees the connection drop mid-response.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
 
 	select {
 	case cb := <-got:
 		return cb, nil
 	case <-ctx.Done():
-		return oauthCallback{}, errors.New("timed out waiting for browser login")
+		return oauthCallback{}, fmt.Errorf("no browser login within %s, run `mobilecli auth login` again", oauthLoginTimeout)
 	}
 }
 

--- a/cli/auth_oauth.go
+++ b/cli/auth_oauth.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -53,7 +54,16 @@ func pkceChallenge(verifier string) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-func buildAuthorizeURL(authorizeURL, redirectURI, challenge, state string) string {
+// detectAgent names the coding agent driving mobilecli, if any, so the server can tell
+// "a human in a terminal" from "Claude Code". Empty when none is recognised.
+func detectAgent(getenv func(string) string) string {
+	if getenv("CLAUDECODE") != "" {
+		return "claude-code"
+	}
+	return ""
+}
+
+func buildAuthorizeURL(authorizeURL, redirectURI, challenge, state, agent string) string {
 	q := url.Values{
 		"response_type":         {"code"},
 		"client_id":             {oauthClientID},
@@ -61,6 +71,9 @@ func buildAuthorizeURL(authorizeURL, redirectURI, challenge, state string) strin
 		"code_challenge":        {challenge},
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
+	}
+	if agent != "" {
+		q.Set("agent", agent)
 	}
 	return authorizeURL + "?" + q.Encode()
 }
@@ -149,7 +162,7 @@ func runOAuthLogin(authorizeURL, tokenURL string) (string, error) {
 	defer listener.Close()
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", listener.Addr().(*net.TCPAddr).Port, oauthCallbackPath)
 
-	loginURL := buildAuthorizeURL(authorizeURL, redirectURI, pkceChallenge(verifier), state)
+	loginURL := buildAuthorizeURL(authorizeURL, redirectURI, pkceChallenge(verifier), state, detectAgent(os.Getenv))
 	if err := openBrowser(loginURL); err != nil {
 		return "", err
 	}

--- a/cli/auth_oauth.go
+++ b/cli/auth_oauth.go
@@ -163,10 +163,13 @@ func runOAuthLogin(authorizeURL, tokenURL string) (string, error) {
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", listener.Addr().(*net.TCPAddr).Port, oauthCallbackPath)
 
 	loginURL := buildAuthorizeURL(authorizeURL, redirectURI, pkceChallenge(verifier), state, detectAgent(os.Getenv))
+	// A missing xdg-open (minimal Linux, WSL) is not fatal: the loopback callback works just as
+	// well when the user pastes the URL themselves.
 	if err := openBrowser(loginURL); err != nil {
-		return "", err
+		fmt.Printf("Could not open a browser (%v). Open this URL to log in:\n\n\t%s\n\n", err, loginURL)
+	} else {
+		fmt.Printf("Opened your browser to log in. If it did not open, visit:\n\n\t%s\n\n", loginURL)
 	}
-	fmt.Printf("Opened your browser to log in. If it did not open, visit:\n\n\t%s\n\n", loginURL)
 	fmt.Println("Waiting for authorization...")
 
 	ctx, cancel := context.WithTimeout(context.Background(), oauthLoginTimeout)

--- a/cli/auth_oauth_test.go
+++ b/cli/auth_oauth_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// RFC 7636 appendix B test vector.
+func TestPkceChallengeMatchesRFC7636Vector(t *testing.T) {
+	got := pkceChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+	if got != "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM" {
+		t.Fatalf("got %s", got)
+	}
+}
+
+func TestBuildAuthorizeURLCarriesPKCEAndState(t *testing.T) {
+	u, err := url.Parse(buildAuthorizeURL("https://x/authorize", "http://127.0.0.1:1234/callback", "chal", "st"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := u.Query()
+	if q.Get("client_id") != "mobilecli" || q.Get("code_challenge") != "chal" || q.Get("code_challenge_method") != "S256" ||
+		q.Get("state") != "st" || q.Get("redirect_uri") != "http://127.0.0.1:1234/callback" || q.Get("response_type") != "code" {
+		t.Fatalf("bad query: %s", u.RawQuery)
+	}
+}
+
+func TestWaitForCallbackReturnsCodeAndState(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		resp, err := http.Get("http://" + listener.Addr().String() + "/callback?code=abc&state=xyz")
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	cb, err := waitForCallback(ctx, listener)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cb.code != "abc" || cb.state != "xyz" {
+		t.Fatalf("got %+v", cb)
+	}
+}
+
+func TestExchangeCodeSendsVerifierAndReturnsToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.PostForm.Get("code_verifier") != "ver" || r.PostForm.Get("code") != "abc" || r.PostForm.Get("client_id") != "mobilecli" {
+			w.WriteHeader(400)
+			w.Write([]byte(`{"error":"invalid_grant"}`))
+			return
+		}
+		w.Write([]byte(`{"access_token":"mob_token","token_type":"bearer"}`))
+	}))
+	defer server.Close()
+
+	token, err := exchangeCode(server.URL, "abc", "ver", "http://127.0.0.1:1/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "mob_token" {
+		t.Fatalf("got %s", token)
+	}
+}

--- a/cli/auth_oauth_test.go
+++ b/cli/auth_oauth_test.go
@@ -19,13 +19,14 @@ func TestPkceChallengeMatchesRFC7636Vector(t *testing.T) {
 }
 
 func TestBuildAuthorizeURLCarriesPKCEAndState(t *testing.T) {
-	u, err := url.Parse(buildAuthorizeURL("https://x/authorize", "http://127.0.0.1:1234/callback", "chal", "st"))
+	u, err := url.Parse(buildAuthorizeURL("https://x/authorize", "http://127.0.0.1:1234/callback", "chal", "st", "claude-code"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	q := u.Query()
 	if q.Get("client_id") != "mobilecli" || q.Get("code_challenge") != "chal" || q.Get("code_challenge_method") != "S256" ||
-		q.Get("state") != "st" || q.Get("redirect_uri") != "http://127.0.0.1:1234/callback" || q.Get("response_type") != "code" {
+		q.Get("state") != "st" || q.Get("redirect_uri") != "http://127.0.0.1:1234/callback" || q.Get("response_type") != "code" ||
+		q.Get("agent") != "claude-code" {
 		t.Fatalf("bad query: %s", u.RawQuery)
 	}
 }
@@ -73,5 +74,14 @@ func TestExchangeCodeSendsVerifierAndReturnsToken(t *testing.T) {
 	}
 	if token != "mob_token" {
 		t.Fatalf("got %s", token)
+	}
+}
+
+func TestDetectAgentRecognisesClaudeCode(t *testing.T) {
+	if got := detectAgent(envWith(map[string]string{"CLAUDECODE": "1"})); got != "claude-code" {
+		t.Fatalf("got %q", got)
+	}
+	if got := detectAgent(envWith(nil)); got != "" {
+		t.Fatalf("expected empty for a plain terminal, got %q", got)
 	}
 }

--- a/cli/auth_oauth_test.go
+++ b/cli/auth_oauth_test.go
@@ -18,15 +18,17 @@ func TestPkceChallengeMatchesRFC7636Vector(t *testing.T) {
 	}
 }
 
+const testAgent = "claude-code"
+
 func TestBuildAuthorizeURLCarriesPKCEAndState(t *testing.T) {
-	u, err := url.Parse(buildAuthorizeURL("https://x/authorize", "http://127.0.0.1:1234/callback", "chal", "st", "claude-code"))
+	u, err := url.Parse(buildAuthorizeURL("https://x/authorize", "http://127.0.0.1:1234/callback", "chal", "st", testAgent))
 	if err != nil {
 		t.Fatal(err)
 	}
 	q := u.Query()
 	if q.Get("client_id") != "mobilecli" || q.Get("code_challenge") != "chal" || q.Get("code_challenge_method") != "S256" ||
 		q.Get("state") != "st" || q.Get("redirect_uri") != "http://127.0.0.1:1234/callback" || q.Get("response_type") != "code" ||
-		q.Get("agent") != "claude-code" {
+		q.Get("agent") != testAgent {
 		t.Fatalf("bad query: %s", u.RawQuery)
 	}
 }
@@ -41,9 +43,17 @@ func TestWaitForCallbackReturnsCodeAndState(t *testing.T) {
 
 	go func() {
 		time.Sleep(50 * time.Millisecond)
-		resp, err := http.Get("http://" + listener.Addr().String() + "/callback?code=abc&state=xyz")
-		if err == nil {
-			resp.Body.Close()
+		callbackURL := "http://" + listener.Addr().String() + "/callback?code=abc&state=xyz"
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
+		if reqErr != nil {
+			return
+		}
+		resp, getErr := http.DefaultClient.Do(req)
+		if getErr != nil {
+			return
+		}
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("failed to close callback response: %v", closeErr)
 		}
 	}()
 
@@ -58,13 +68,16 @@ func TestWaitForCallbackReturnsCodeAndState(t *testing.T) {
 
 func TestExchangeCodeSendsVerifierAndReturnsToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseForm()
-		if r.PostForm.Get("code_verifier") != "ver" || r.PostForm.Get("code") != "abc" || r.PostForm.Get("client_id") != "mobilecli" {
-			w.WriteHeader(400)
-			w.Write([]byte(`{"error":"invalid_grant"}`))
+		if parseErr := r.ParseForm(); parseErr != nil {
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		w.Write([]byte(`{"access_token":"mob_token","token_type":"bearer"}`))
+		if r.PostForm.Get("code_verifier") != "ver" || r.PostForm.Get("code") != "abc" || r.PostForm.Get("client_id") != "mobilecli" {
+			w.WriteHeader(http.StatusBadRequest)
+			writeTestResponse(t, w, `{"error":"invalid_grant"}`)
+			return
+		}
+		writeTestResponse(t, w, `{"access_token":"mob_token","token_type":"bearer"}`)
 	}))
 	defer server.Close()
 
@@ -83,5 +96,13 @@ func TestDetectAgentRecognisesClaudeCode(t *testing.T) {
 	}
 	if got := detectAgent(envWith(nil)); got != "" {
 		t.Fatalf("expected empty for a plain terminal, got %q", got)
+	}
+}
+
+func writeTestResponse(t *testing.T, w http.ResponseWriter, body string) {
+	t.Helper()
+
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Errorf("failed to write test response: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
`mobilecli auth login` now opens the browser to the OAuth consent screen (pick organization, click Approve) and receives the code on an ephemeral loopback port with PKCE. No code to type.

Device code is used only when a browser is unlikely: `--no-browser`, SSH session, `CI` set, or Linux/BSD with no `DISPLAY`/`WAYLAND_DISPLAY`.

- `cli/auth_browser.go`: detection + `openBrowser` (open / xdg-open / rundll32). Open failure is non-fatal; the URL is printed and the callback still works.
- `cli/auth_oauth.go`: PKCE S256, loopback listener, state check, code exchange. Sends `agent=claude-code` when `CLAUDECODE` is set.
- `cli/auth.go`: routes to OAuth or device code; token is org-bound from the consent screen.

Requires the server side: mobile-next/backend `feat/device-login-prefill-code`. Until that deploys, browser login fails with `invalid_client`.

## Test plan
- [x] `go test ./cli/` passes: detection table, RFC 7636 PKCE vector, callback listener, code exchange
- [x] Cross-compiles for linux and windows
- [x] `--no-browser` path verified locally
- [ ] Browser path end to end after server deploy
- [ ] Manual check on Linux and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Browser-based OAuth is now the default login method.
  - Device-code login is used automatically for SSH, CI, headless environments, or with `--no-browser`.
  - Added the `--no-browser` login option.
  - Added secure OAuth authorization with callback validation, PKCE, and token exchange.

- **Bug Fixes**
  - Improved verbose reporting when opening the browser fails.

- **Tests**
  - Added coverage for browser detection, PKCE, callback handling, token exchange, and OAuth login flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->