### PR TITLE
fix: report real app name and focused activity for android foreground app

### DIFF
--- a/devices/android.go
+++ b/devices/android.go
@@ -1065,30 +1065,32 @@ func parsePackageListerOutput(output []byte) ([]InstalledAppInfo, error) {
 	return apps, nil
 }
 
-func (d *AndroidDevice) getForegroundPackageName() (string, error) {
+// getForegroundComponent returns the package name and activity of the focused
+// window. Note that mCurrentFocus also reports dialogs and the IME.
+func (d *AndroidDevice) getForegroundComponent() (string, string, error) {
 	output, err := d.runAdbCommand("shell", "dumpsys", "window", "displays")
 	if err != nil {
-		return "", fmt.Errorf("failed to get window displays: %w", err)
+		return "", "", fmt.Errorf("failed to get window displays: %w", err)
 	}
 
 	// parse package name from mCurrentFocus line
-	// format: mCurrentFocus=Window{...u0 com.package.name/...}
+	// format: mCurrentFocus=Window{... u0 com.package.name/com.package.name.MainActivity}
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines {
 		if strings.Contains(line, "mCurrentFocus") {
 			parts := strings.Fields(line)
 			if len(parts) >= 3 {
-				focusPart := parts[2]
-				// extract package name (before the '/')
+				focusPart := strings.TrimSuffix(parts[2], "}")
+				// split into package name (before the '/') and activity (after)
 				if idx := strings.Index(focusPart, "/"); idx != -1 {
-					return focusPart[:idx], nil
+					return focusPart[:idx], focusPart[idx+1:], nil
 				}
 			}
 			break
 		}
 	}
 
-	return "", fmt.Errorf("could not determine foreground app")
+	return "", "", fmt.Errorf("could not determine foreground app")
 }
 
 func (d *AndroidDevice) GetAppVersion(packageName string) (string, error) {
@@ -1112,14 +1114,38 @@ func (d *AndroidDevice) GetAppVersion(packageName string) (string, error) {
 	return "", nil
 }
 
+// resolveAppName returns the launcher label for a package. The label lives in
+// the package's resources, so it needs the on-device agent; without it, callers
+// still get the package name rather than an error.
+func (d *AndroidDevice) resolveAppName(packageName string) string {
+	apps, err := d.listAllPackages()
+	if err != nil {
+		return packageName
+	}
+
+	return appNameFor(apps, packageName)
+}
+
+// appNameFor picks a package's label out of a listing, falling back to the
+// package name when the package is missing or carries no label.
+func appNameFor(apps []InstalledAppInfo, packageName string) string {
+	for _, app := range apps {
+		if app.PackageName == packageName && app.AppName != "" {
+			return app.AppName
+		}
+	}
+
+	return packageName
+}
+
 func (d *AndroidDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 	// dumpsys returns a null focus while animations are running, so retry for
 	// up to 5 seconds (every 250ms) before giving up.
-	var packageName string
+	var packageName, activity string
 	var err error
 	deadline := time.Now().Add(5 * time.Second)
 	for {
-		packageName, err = d.getForegroundPackageName()
+		packageName, activity, err = d.getForegroundComponent()
 		if err == nil {
 			break
 		}
@@ -1138,8 +1164,9 @@ func (d *AndroidDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 
 	return &ForegroundAppInfo{
 		PackageName: packageName,
-		AppName:     packageName,
+		AppName:     d.resolveAppName(packageName),
 		Version:     version,
+		Activity:    activity,
 	}, nil
 }
 

--- a/devices/android_apps_test.go
+++ b/devices/android_apps_test.go
@@ -23,3 +23,30 @@ func TestParsePackageListerOutputRejectsNonJSON(t *testing.T) {
 		t.Fatal("expected error for non-JSON output")
 	}
 }
+
+func TestAppNameForReturnsLabel(t *testing.T) {
+	apps := []InstalledAppInfo{
+		{PackageName: "com.mobilenext.devicekit", AppName: "DeviceKit"},
+		{PackageName: "com.mobilenext.playground", AppName: "Playground"},
+	}
+
+	if got := appNameFor(apps, "com.mobilenext.playground"); got != "Playground" {
+		t.Errorf("got %q, want %q", got, "Playground")
+	}
+}
+
+func TestAppNameForFallsBackToPackageNameWhenUnknown(t *testing.T) {
+	apps := []InstalledAppInfo{{PackageName: "com.mobilenext.devicekit", AppName: "DeviceKit"}}
+
+	if got := appNameFor(apps, "com.example.missing"); got != "com.example.missing" {
+		t.Errorf("got %q, want the package name back", got)
+	}
+}
+
+func TestAppNameForFallsBackWhenLabelIsEmpty(t *testing.T) {
+	apps := []InstalledAppInfo{{PackageName: "com.example.nolabel", AppName: ""}}
+
+	if got := appNameFor(apps, "com.example.nolabel"); got != "com.example.nolabel" {
+		t.Errorf("got %q, want the package name back", got)
+	}
+}

--- a/devices/common.go
+++ b/devices/common.go
@@ -447,4 +447,7 @@ type ForegroundAppInfo struct {
 	PackageName string `json:"packageName"`
 	AppName     string `json:"appName"`
 	Version     string `json:"version"`
+	// Activity is the focused component within the app: activity class on
+	// Android, empty on iOS.
+	Activity string `json:"activity,omitempty"`
 }


### PR DESCRIPTION
## Problem

`mobilecli apps foreground` on Android echoed the package name twice:

```json
{ "packageName": "com.mobilenext.playground", "appName": "com.mobilenext.playground", "version": "1.0" }
```

`GetForegroundApp` assigned `AppName: packageName` directly. iOS resolves a real label, so the two platforms disagreed.

## Fix

The label was already available. `PackageLister.displayName` on the agent side resolves it through `nonLocalizedLabel` and then the package's own resources, and `ListApps` already returns it. The foreground path just never asked, so it now looks the package up in that listing.

No change was needed in `agents/android`.

When the on-device agent is unavailable the listing call fails and callers get the package name back rather than an error, so setups without the agent behave as before.

Also included: the activity is parsed out of the `mCurrentFocus` component and exposed as an optional `activity` field, since dumpsys already reports it next to the package.

## Result

```json
{
  "packageName": "com.mobilenext.playground",
  "appName": "Playground",
  "version": "1.0",
  "activity": "com.mobilenext.playground.BasicUIActivity"
}
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./devices/`
- [x] `go test ./devices/` passes
- [x] Three new unit tests on `appNameFor`: label found, package absent from the listing, package present with an empty label
- [x] Verified against a Pixel 9 Pro emulator, output above
- [ ] Verify on a device without the agent installed, expecting the package name as the fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Foreground app information now includes the currently focused Android activity.
  - Android app names are displayed using their launcher labels when available.
  - If no launcher label is found, the package name is shown instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->