### PR TITLE
feat: report the on-screen view controller as the activity on ios

### DIFF
--- a/devices/common.go
+++ b/devices/common.go
@@ -448,6 +448,6 @@ type ForegroundAppInfo struct {
 	AppName     string `json:"appName"`
 	Version     string `json:"version"`
 	// Activity is the focused component within the app: activity class on
-	// Android, empty on iOS.
+	// Android, view controller class on iOS.
 	Activity string `json:"activity,omitempty"`
 }

--- a/devices/devicekit/active-app.go
+++ b/devices/devicekit/active-app.go
@@ -10,6 +10,9 @@ type ActiveAppInfo struct {
 	BundleID  string `json:"bundleId"`
 	Name      string `json:"name"`
 	ProcessID int    `json:"pid"`
+	// ViewController is the class name of the controller presenting the current
+	// screen. Empty when the agent predates the field or has nothing to report.
+	ViewController string `json:"viewController"`
 }
 
 func (c *DeviceKitClient) GetActiveAppInfo() (*ActiveAppInfo, error) {

--- a/devices/devicekit/active-app_test.go
+++ b/devices/devicekit/active-app_test.go
@@ -1,0 +1,37 @@
+package devicekit
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestActiveAppInfoReadsViewController(t *testing.T) {
+	payload := []byte(`{"bundleId":"com.mobilenext.playground","name":"Playground","pid":19917,"viewController":"SwiftUI.NavigationStackHostingController<SwiftUI.AnyView>"}`)
+
+	var info ActiveAppInfo
+	if err := json.Unmarshal(payload, &info); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.ViewController != "SwiftUI.NavigationStackHostingController<SwiftUI.AnyView>" {
+		t.Errorf("got %q, want the view controller class name", info.ViewController)
+	}
+}
+
+// An agent older than the view controller support omits the field entirely.
+func TestActiveAppInfoWithoutViewControllerIsEmptyNotAnError(t *testing.T) {
+	payload := []byte(`{"bundleId":"com.apple.mobilesafari","name":"Safari","pid":48787}`)
+
+	var info ActiveAppInfo
+	if err := json.Unmarshal(payload, &info); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.ViewController != "" {
+		t.Errorf("got %q, want an empty view controller", info.ViewController)
+	}
+
+	if info.BundleID != "com.apple.mobilesafari" {
+		t.Errorf("got %q, want the bundle id to still be parsed", info.BundleID)
+	}
+}

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -939,6 +939,7 @@ func (d *IOSDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 				PackageName: app.PackageName,
 				AppName:     app.AppName,
 				Version:     app.Version,
+				Activity:    activeApp.ViewController,
 			}, nil
 		}
 	}
@@ -948,6 +949,7 @@ func (d *IOSDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 		PackageName: activeApp.BundleID,
 		AppName:     activeApp.Name,
 		Version:     "",
+		Activity:    activeApp.ViewController,
 	}, nil
 }
 

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -677,6 +677,7 @@ func (s *SimulatorDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 				PackageName: app.PackageName,
 				AppName:     app.AppName,
 				Version:     app.Version,
+				Activity:    activeApp.ViewController,
 			}, nil
 		}
 	}
@@ -686,6 +687,7 @@ func (s *SimulatorDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 		PackageName: activeApp.BundleID,
 		AppName:     activeApp.Name,
 		Version:     "",
+		Activity:    activeApp.ViewController,
 	}, nil
 }
 


### PR DESCRIPTION
Stacked on #403. Review that one first; this PR targets its branch, so the diff here is only the iOS part.

## What

The `activity` field was Android-only. iOS now fills in the same field with the view controller presenting the current screen, so both platforms answer "what screen am I on" identically.

```
$ mobilecli apps foreground --device <ios-udid>
{ "packageName": "com.mobilenext.playground", "appName": "Playground", "version": "1.0",
  "activity": "SwiftUI.NavigationStackHostingController<SwiftUI.AnyView>" }

$ mobilecli apps foreground --device Pixel_9_Pro
{ "packageName": "com.android.chrome", "appName": "Chrome", "version": "152.0.7977.75",
  "activity": "org.chromium.chrome.browser.ChromeTabbedActivity" }
```

## How

The work is on the agent side, in devicekit-ios#77, which adds a `viewController` field to `device.apps.foreground`. This change is only the client half: the field is picked up in `ActiveAppInfo` and mapped onto `ForegroundAppInfo.Activity` in both the device and simulator paths, covering the matched-app and system-app branches.

It stays empty against an agent that predates the field, so an older agent keeps working rather than erroring.

## Test plan

- [x] `go build ./...`, `go vet ./devices/`, `go test ./devices/` pass
- [x] Verified on an iOS 26 simulator against Playground, Settings and SpringBoard
- [x] Verified Android still reports its activity, so the shared field behaves the same on both
- [ ] Verify on a real iOS device
- [ ] Requires devicekit-ios#77 to be released before the field appears with a shipped agent