### PR TITLE
feat: return both android activity and ios viewcontroller that is currently focused

### DIFF
--- a/devices/common.go
+++ b/devices/common.go
@@ -448,6 +448,6 @@ type ForegroundAppInfo struct {
 	AppName     string `json:"appName"`
 	Version     string `json:"version"`
 	// Activity is the focused component within the app: activity class on
-	// Android, empty on iOS.
+	// Android, view controller class on iOS.
 	Activity string `json:"activity,omitempty"`
 }

--- a/devices/devicekit/active-app.go
+++ b/devices/devicekit/active-app.go
@@ -10,6 +10,9 @@ type ActiveAppInfo struct {
 	BundleID  string `json:"bundleId"`
 	Name      string `json:"name"`
 	ProcessID int    `json:"pid"`
+	// ViewController is the class name of the controller presenting the current
+	// screen. Empty when the agent predates the field or has nothing to report.
+	ViewController string `json:"viewController"`
 }
 
 func (c *DeviceKitClient) GetActiveAppInfo() (*ActiveAppInfo, error) {

--- a/devices/devicekit/active-app_test.go
+++ b/devices/devicekit/active-app_test.go
@@ -1,0 +1,37 @@
+package devicekit
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestActiveAppInfoReadsViewController(t *testing.T) {
+	payload := []byte(`{"bundleId":"com.mobilenext.playground","name":"Playground","pid":19917,"viewController":"SwiftUI.NavigationStackHostingController<SwiftUI.AnyView>"}`)
+
+	var info ActiveAppInfo
+	if err := json.Unmarshal(payload, &info); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.ViewController != "SwiftUI.NavigationStackHostingController<SwiftUI.AnyView>" {
+		t.Errorf("got %q, want the view controller class name", info.ViewController)
+	}
+}
+
+// An agent older than the view controller support omits the field entirely.
+func TestActiveAppInfoWithoutViewControllerIsEmptyNotAnError(t *testing.T) {
+	payload := []byte(`{"bundleId":"com.apple.mobilesafari","name":"Safari","pid":48787}`)
+
+	var info ActiveAppInfo
+	if err := json.Unmarshal(payload, &info); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.ViewController != "" {
+		t.Errorf("got %q, want an empty view controller", info.ViewController)
+	}
+
+	if info.BundleID != "com.apple.mobilesafari" {
+		t.Errorf("got %q, want the bundle id to still be parsed", info.BundleID)
+	}
+}

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -939,6 +939,7 @@ func (d *IOSDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 				PackageName: app.PackageName,
 				AppName:     app.AppName,
 				Version:     app.Version,
+				Activity:    activeApp.ViewController,
 			}, nil
 		}
 	}
@@ -948,6 +949,7 @@ func (d *IOSDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 		PackageName: activeApp.BundleID,
 		AppName:     activeApp.Name,
 		Version:     "",
+		Activity:    activeApp.ViewController,
 	}, nil
 }
 

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -677,6 +677,7 @@ func (s *SimulatorDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 				PackageName: app.PackageName,
 				AppName:     app.AppName,
 				Version:     app.Version,
+				Activity:    activeApp.ViewController,
 			}, nil
 		}
 	}
@@ -686,6 +687,7 @@ func (s *SimulatorDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
 		PackageName: activeApp.BundleID,
 		AppName:     activeApp.Name,
 		Version:     "",
+		Activity:    activeApp.ViewController,
 	}, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Foreground app information now includes the active activity or view controller on Android, iOS, and simulators.
  * Android foreground apps now display their launcher label when available, with the package name used as a fallback.

* **Compatibility**
  * Apps without activity or view-controller information continue to be reported successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->