### PR TITLE
fix: don't hang on a locked keyring when reading credentials

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -246,7 +246,7 @@ var authTokenCmd = &cobra.Command{
 	Short: "Display the current auth token",
 	Long:  `Displays the authentication token for the current session.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		token, err := loadToken()
+		token, err := loadTokenWithTimeout()
 		if err != nil {
 			if errors.Is(err, keyring.ErrNotFound) {
 				return fmt.Errorf("no auth token found for mobilecli")

--- a/cli/credentials.go
+++ b/cli/credentials.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/zalando/go-keyring"
 )
@@ -84,6 +86,51 @@ func loadToken() (string, error) {
 		return "", fmt.Errorf("failed to get token from keyring: %w", err)
 	}
 	return token, nil
+}
+
+// tokenLoadTimeout bounds how long loading a token from the OS keyring may
+// block. Some keyring backends never return - notably the freedesktop Secret
+// Service when its login collection is locked and no interactive prompter is
+// available (e.g. commands auto-started from an SSH session). Without this
+// bound, every command that touches the keyring would hang forever.
+const tokenLoadTimeout = 3 * time.Second
+
+var (
+	tokenLoadOnce sync.Once
+	tokenLoadVal  string
+	tokenLoadErr  error
+)
+
+// loadTokenWithTimeout is loadToken with a hard deadline, memoized so the
+// timeout is paid at most once per process. Callers that must not hang, like
+// the root pre-run and daemon startup, use this instead of loadToken.
+func loadTokenWithTimeout() (string, error) {
+	tokenLoadOnce.Do(func() {
+		tokenLoadVal, tokenLoadErr = loadTokenDeadline(loadToken, tokenLoadTimeout)
+	})
+	return tokenLoadVal, tokenLoadErr
+}
+
+// loadTokenDeadline runs fn but gives up after timeout. It is split out from
+// loadTokenWithTimeout so the deadline behavior can be unit-tested.
+func loadTokenDeadline(fn func() (string, error), timeout time.Duration) (string, error) {
+	type result struct {
+		token string
+		err   error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		token, err := fn()
+		ch <- result{token: token, err: err}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.token, r.err
+	case <-time.After(timeout):
+		return "", fmt.Errorf("timed out after %s reading credentials; the OS keyring may be locked (unlock it, or use --insecure-storage)", timeout)
+	}
 }
 
 func loadTokenFromFile() (string, error) {

--- a/cli/credentials.go
+++ b/cli/credentials.go
@@ -138,7 +138,7 @@ func loadTokenFromFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is the fixed credentials file under the user config dir
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", keyring.ErrNotFound

--- a/cli/credentials_test.go
+++ b/cli/credentials_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/zalando/go-keyring"
 )
@@ -166,5 +168,29 @@ func TestDeleteTokenRemovesFile(t *testing.T) {
 
 	if err := deleteToken(); !errors.Is(err, keyring.ErrNotFound) {
 		t.Fatalf("second deleteToken err = %v, want keyring.ErrNotFound", err)
+	}
+}
+
+func TestLoadTokenDeadlineReturnsResult(t *testing.T) {
+	got, err := loadTokenDeadline(func() (string, error) { return "tok", nil }, time.Second)
+	if err != nil {
+		t.Fatalf("loadTokenDeadline: %v", err)
+	}
+	if got != "tok" {
+		t.Fatalf("loadTokenDeadline = %q, want %q", got, "tok")
+	}
+}
+
+func TestLoadTokenDeadlineTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	_, err := loadTokenDeadline(func() (string, error) {
+		<-release
+		return "late", nil
+	}, 50*time.Millisecond)
+
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("loadTokenDeadline err = %v, want timeout error", err)
 	}
 }

--- a/cli/credentials_test.go
+++ b/cli/credentials_test.go
@@ -80,7 +80,10 @@ func TestInsecureStorageUsesFileAndSkipsKeyring(t *testing.T) {
 		t.Fatalf("storeToken with --insecure-storage: %v", err)
 	}
 
-	path, _ := credentialsFilePath()
+	path, err := credentialsFilePath()
+	if err != nil {
+		t.Fatalf("credentialsFilePath: %v", err)
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("credentials file was not written: %v", err)
@@ -108,7 +111,10 @@ func TestKeyringStorageDoesNotWriteFile(t *testing.T) {
 		t.Fatalf("storeToken: %v", err)
 	}
 
-	path, _ := credentialsFilePath()
+	path, err := credentialsFilePath()
+	if err != nil {
+		t.Fatalf("credentialsFilePath: %v", err)
+	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("no credentials file should exist without --insecure-storage, stat err = %v", err)
 	}
@@ -161,7 +167,10 @@ func TestDeleteTokenRemovesFile(t *testing.T) {
 		t.Fatalf("deleteToken: %v", err)
 	}
 
-	path, _ := credentialsFilePath()
+	path, err := credentialsFilePath()
+	if err != nil {
+		t.Fatalf("credentialsFilePath: %v", err)
+	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("credentials file should be gone, stat err = %v", err)
 	}

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -92,7 +92,7 @@ func runDaemon() error {
 	commands.SetShutdownHook(hook)
 	// not being logged in is normal; anything else (unreadable keyring) is
 	// worth a line in the daemon log since remote devices silently vanish
-	if token, err := loadToken(); err == nil {
+	if token, err := loadTokenWithTimeout(); err == nil {
 		commands.SetFleetConfig(token)
 	} else if !errors.Is(err, keyring.ErrNotFound) {
 		utils.Info("fleet token unavailable, remote devices disabled: %v", err)

--- a/cli/remote.go
+++ b/cli/remote.go
@@ -12,7 +12,7 @@ import (
 )
 
 func getRemoteToken() (string, error) {
-	token, err := loadToken()
+	token, err := loadTokenWithTimeout()
 	if err != nil {
 		if errors.Is(err, keyring.ErrNotFound) {
 			return "", fmt.Errorf("not logged in, run 'mobilecli auth login' first")


### PR DESCRIPTION
Fixes #407.

`loadToken()` calls `keyring.Get()` with no deadline, so on a host with a locked freedesktop Secret Service (no reachable prompter) every command hangs forever - including local ones like `devices`, because the root PersistentPreRunE loads the fleet token for every invocation and the auto-started daemon loads it again at startup.

This PR bounds the read paths:

- adds `loadTokenWithTimeout()` - a memoized 3s deadline (the timeout is paid at most once per process; the daemon's second load hits the cache)
- uses it in the root pre-run / `getRemoteToken()`, daemon startup, and `auth token`
- on timeout the daemon logs `fleet token unavailable ... timed out after 3s ...` and continues without remote devices

Write/delete paths are intentionally unchanged (a login flow may legitimately want to wait for a keyring prompt).

### Validation on the affected host (locked keyring, remote tty)

| | before | after |
|---|---|---|
| `mobilecli devices` | hangs forever (`exit 124`) | returns the device list in ~6.4s cold / ~3.2s warm |
| foreground `daemon start` | never reaches listening | logs the timeout: `fleet token unavailable, remote devices disabled: timed out after 3s reading credentials; the OS keyring may be locked (unlock it, or use --insecure-storage)` and listens after 3s |

`go test ./cli/`, `go vet ./cli/...` and `gofmt` all pass. Two new unit tests cover the deadline helper (`TestLoadTokenDeadlineReturnsResult`, `TestLoadTokenDeadlineTimesOut`).

Note: the per-process 3s wait still applies on every CLI invocation on these hosts. If you'd rather only load credentials for commands that actually need the fleet (lazy-load), I'm happy to rework it - this version keeps behavior otherwise identical and fixes the hang.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a three-second timeout when retrieving stored authentication tokens.
  * Prevented authentication commands, remote operations, and daemon startup from hanging when the system keyring is unresponsive.
  * Preserved existing handling for missing or unavailable credentials.
  * Improved error reporting when credential file paths cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->