### PR TITLE
feat: two-finger pinch via io pinch, multi-finger gesture through the Android agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.10](https://github.com/mobile-next/mobilecli/releases/tag/1.0.10) (unreleased)
+* Feat: Pinch to zoom with `mobilecli io pinch` and `device.io.pinch`, and a real multi-finger `device.io.gesture` on Android through the embedded agent ([#410](https://github.com/mobile-next/mobilecli/pull/410))
+
 ## [1.0.9](https://github.com/mobile-next/mobilecli/releases/tag/1.0.9) (2026-09-08)
 * Feat: add `--full` flag to `dump ui` to include the on-screen keyboard ([#398](https://github.com/mobile-next/mobilecli/pull/398))
 * Docs: teach the mobilecli skill install, element refs, command chaining and remote devices ([#397](https://github.com/mobile-next/mobilecli/pull/397))

--- a/agents/android/java/DeviceServer.java
+++ b/agents/android/java/DeviceServer.java
@@ -16,7 +16,7 @@ import java.security.MessageDigest;
 
 /**
  * Persistent device server via app_process. Keeps one connected UiAutomation
- * alive and serves UI dump, screenshot, keyboard, clipboard, app list and mock location
+ * alive and serves UI dump, screenshot, keyboard, touch gestures, clipboard, app list and mock location
  * over JSON-RPC on a localabstract socket, so repeated calls skip process-fork
  * and connect cost, and long-lived state (test location providers) has a home.
  *
@@ -62,6 +62,8 @@ public class DeviceServer {
 				return screenshot(automation, p);
 			case "device.io.keyboard.hide":
 				return new JSONObject().put("dismissed", hideKeyboard(automation));
+			case "device.io.gesture":
+				return Gestures.perform(automation, p.optJSONArray("actions"));
 			case "device.clipboard.get":
 				return new JSONObject().put("text", orEmpty(Clipboard.getText()));
 			case "device.clipboard.set":

--- a/agents/android/java/Gestures.java
+++ b/agents/android/java/Gestures.java
@@ -1,0 +1,243 @@
+package com.mobilenext.mobilecli;
+
+import android.app.UiAutomation;
+import android.os.SystemClock;
+import android.view.InputDevice;
+import android.view.MotionEvent;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Multi-finger touch injection through the server's UiAutomation, the same
+ * object uiautomator's own pinch uses. Served by DeviceServer as
+ * "device.io.gesture" with the contract devicekit-ios already speaks: a flat
+ * list of {type: press|move|release, x, y, duration, button}, where button is
+ * the finger index and duration is in seconds.
+ *
+ * Actions are grouped by finger and every finger's timeline starts at zero,
+ * so two fingers travel at the same time; that is what makes a pinch a pinch
+ * rather than two swipes. press holds for its duration before the first move,
+ * move travels to (x, y) over its duration, release waits its duration at the
+ * last point and then lifts. The whole gesture is replayed in real time, one
+ * MotionEvent per frame carrying every finger that is currently down.
+ */
+public class Gestures {
+
+	private static final long FRAME_MS = 16; // ~60 fps, what a real touchscreen reports
+
+	private static final String TYPE_PRESS = "press";
+	private static final String TYPE_MOVE = "move";
+	private static final String TYPE_RELEASE = "release";
+
+	/** One point on a finger's path, at an offset from the gesture start. */
+	private static class Keyframe {
+		final long atMs;
+		final float x, y;
+
+		Keyframe(long atMs, float x, float y) {
+			this.atMs = atMs;
+			this.x = x;
+			this.y = y;
+		}
+	}
+
+	/** A finger's whole path; it is down from time zero until the last keyframe. */
+	private static class Finger {
+		final int id;
+		final List<Keyframe> path = new ArrayList<>();
+
+		Finger(int id) {
+			this.id = id;
+		}
+
+		long liftAtMs() {
+			return path.get(path.size() - 1).atMs;
+		}
+
+		Keyframe positionAt(long atMs) {
+			Keyframe previous = path.get(0);
+			for (Keyframe next : path) {
+				if (atMs <= next.atMs) {
+					if (next.atMs == previous.atMs) return next;
+					float fraction = (float) (atMs - previous.atMs) / (next.atMs - previous.atMs);
+					return new Keyframe(atMs, previous.x + (next.x - previous.x) * fraction,
+							previous.y + (next.y - previous.y) * fraction);
+				}
+				previous = next;
+			}
+			return previous;
+		}
+	}
+
+	static JSONObject perform(UiAutomation automation, JSONArray actions) throws Exception {
+		List<Finger> fingers = parseFingers(actions);
+		replay(automation, fingers);
+		return new JSONObject().put("ok", true);
+	}
+
+	// Groups actions by button into per-finger paths, validating the same way
+	// devicekit-ios does so both platforms reject the same input.
+	private static List<Finger> parseFingers(JSONArray actions) throws Exception {
+		if (actions == null || actions.length() == 0) {
+			throw new RpcException(RpcException.INVALID_PARAMS, "actions array cannot be empty");
+		}
+
+		Map<Integer, List<JSONObject>> byFinger = new TreeMap<>();
+		for (int i = 0; i < actions.length(); i++) {
+			JSONObject action = actions.getJSONObject(i);
+			int button = action.optInt("button", 0);
+			if (!byFinger.containsKey(button)) byFinger.put(button, new ArrayList<JSONObject>());
+			byFinger.get(button).add(action);
+		}
+
+		List<Finger> fingers = new ArrayList<>();
+		for (Map.Entry<Integer, List<JSONObject>> entry : byFinger.entrySet()) {
+			fingers.add(buildFinger(entry.getKey(), entry.getValue()));
+		}
+		return fingers;
+	}
+
+	private static Finger buildFinger(int id, List<JSONObject> actions) throws Exception {
+		Finger finger = new Finger(id);
+		long atMs = 0;
+		boolean released = false;
+
+		for (int i = 0; i < actions.size(); i++) {
+			JSONObject action = actions.get(i);
+			String type = action.optString("type", "");
+			float x = (float) action.optDouble("x", 0);
+			float y = (float) action.optDouble("y", 0);
+			long durationMs = Math.round(action.optDouble("duration", 0) * 1000);
+
+			if (x < 0 || y < 0) {
+				throw new RpcException(RpcException.INVALID_PARAMS,
+						"finger " + id + " has negative coordinates at index " + i);
+			}
+			if (durationMs < 0) {
+				throw new RpcException(RpcException.INVALID_PARAMS,
+						"finger " + id + " has negative duration at index " + i);
+			}
+			if (released) {
+				throw new RpcException(RpcException.INVALID_PARAMS,
+						"finger " + id + " has actions after 'release' at index " + i);
+			}
+
+			switch (type) {
+				case TYPE_PRESS:
+					if (i != 0) {
+						throw new RpcException(RpcException.INVALID_PARAMS,
+								"finger " + id + " has 'press' after its first action at index " + i);
+					}
+					finger.path.add(new Keyframe(0, x, y));
+					atMs += durationMs;
+					finger.path.add(new Keyframe(atMs, x, y));
+					break;
+				case TYPE_MOVE:
+					if (i == 0) {
+						throw new RpcException(RpcException.INVALID_PARAMS,
+								"finger " + id + " must start with 'press', got 'move'");
+					}
+					atMs += durationMs;
+					finger.path.add(new Keyframe(atMs, x, y));
+					break;
+				case TYPE_RELEASE:
+					if (i == 0) {
+						throw new RpcException(RpcException.INVALID_PARAMS,
+								"finger " + id + " must start with 'press', got 'release'");
+					}
+					Keyframe last = finger.path.get(finger.path.size() - 1);
+					atMs += durationMs;
+					finger.path.add(new Keyframe(atMs, last.x, last.y));
+					released = true;
+					break;
+				default:
+					throw new RpcException(RpcException.INVALID_PARAMS,
+							"finger " + id + " has unknown action type '" + type + "' at index " + i);
+			}
+		}
+
+		if (!released) {
+			throw new RpcException(RpcException.INVALID_PARAMS, "finger " + id + " must end with 'release'");
+		}
+		return finger;
+	}
+
+	// Presses every finger at time zero, then walks the timeline a frame at a
+	// time: one ACTION_MOVE for all fingers still down, then a lift for each
+	// finger whose path has ended, until the last one is up.
+	private static void replay(UiAutomation automation, List<Finger> fingers) {
+		long endMs = 0;
+		for (Finger finger : fingers) endMs = Math.max(endMs, finger.liftAtMs());
+
+		long downTime = SystemClock.uptimeMillis();
+		List<Finger> down = new ArrayList<>();
+		for (Finger finger : fingers) {
+			down.add(finger);
+			int action = down.size() == 1
+					? MotionEvent.ACTION_DOWN
+					: MotionEvent.ACTION_POINTER_DOWN | ((down.size() - 1) << MotionEvent.ACTION_POINTER_INDEX_SHIFT);
+			inject(automation, downTime, downTime, action, down, 0);
+		}
+
+		for (long atMs = FRAME_MS; !down.isEmpty(); atMs += FRAME_MS) {
+			if (atMs > endMs) atMs = endMs;
+			sleepUntil(downTime + atMs);
+			long eventTime = SystemClock.uptimeMillis();
+
+			inject(automation, downTime, eventTime, MotionEvent.ACTION_MOVE, down, atMs);
+
+			for (int i = 0; i < down.size(); ) {
+				Finger finger = down.get(i);
+				if (finger.liftAtMs() > atMs) {
+					i++;
+					continue;
+				}
+				int action = down.size() == 1
+						? MotionEvent.ACTION_UP
+						: MotionEvent.ACTION_POINTER_UP | (i << MotionEvent.ACTION_POINTER_INDEX_SHIFT);
+				inject(automation, downTime, eventTime, action, down, atMs);
+				down.remove(i);
+			}
+		}
+	}
+
+	private static void inject(UiAutomation automation, long downTime, long eventTime, int action,
+			List<Finger> pointers, long atMs) {
+		int count = pointers.size();
+		MotionEvent.PointerProperties[] properties = new MotionEvent.PointerProperties[count];
+		MotionEvent.PointerCoords[] coords = new MotionEvent.PointerCoords[count];
+		for (int i = 0; i < count; i++) {
+			Finger finger = pointers.get(i);
+			Keyframe at = finger.positionAt(Math.min(atMs, finger.liftAtMs()));
+
+			properties[i] = new MotionEvent.PointerProperties();
+			properties[i].id = finger.id;
+			properties[i].toolType = MotionEvent.TOOL_TYPE_FINGER;
+
+			coords[i] = new MotionEvent.PointerCoords();
+			coords[i].x = at.x;
+			coords[i].y = at.y;
+			coords[i].pressure = 1;
+			coords[i].size = 1;
+		}
+
+		MotionEvent event = MotionEvent.obtain(downTime, eventTime, action, count, properties, coords,
+				0, 0, 1, 1, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0);
+		try {
+			automation.injectInputEvent(event, true);
+		} finally {
+			event.recycle();
+		}
+	}
+
+	private static void sleepUntil(long uptimeMs) {
+		long wait = uptimeMs - SystemClock.uptimeMillis();
+		if (wait > 0) SystemClock.sleep(wait);
+	}
+}

--- a/agents/android/java/Gestures.java
+++ b/agents/android/java/Gestures.java
@@ -31,6 +31,11 @@ public class Gestures {
 
 	private static final long FRAME_MS = 16; // ~60 fps, what a real touchscreen reports
 
+	// JsonRpcSocketServer serves one request at a time, and replay sleeps for
+	// the whole gesture, so an over-long one would stall every other call
+	// (screenshots included) until it ends. Nothing legitimate takes this long.
+	private static final long MAX_GESTURE_MS = 30_000;
+
 	private static final String TYPE_PRESS = "press";
 	private static final String TYPE_MOVE = "move";
 	private static final String TYPE_RELEASE = "release";
@@ -77,6 +82,12 @@ public class Gestures {
 
 	static JSONObject perform(UiAutomation automation, JSONArray actions) throws Exception {
 		List<Finger> fingers = parseFingers(actions);
+		long endMs = 0;
+		for (Finger finger : fingers) endMs = Math.max(endMs, finger.liftAtMs());
+		if (endMs > MAX_GESTURE_MS) {
+			throw new RpcException(RpcException.INVALID_PARAMS,
+					"gesture is " + endMs + "ms long, the limit is " + MAX_GESTURE_MS + "ms");
+		}
 		replay(automation, fingers);
 		return new JSONObject().put("ok", true);
 	}

--- a/cli/io.go
+++ b/cli/io.go
@@ -57,6 +57,9 @@ var ioTapCmd = &cobra.Command{
 
 var longPressDuration int
 var swipeDuration int
+var pinchDirection string
+var pinchDistance int
+var pinchDuration int
 
 var ioLongPressCmd = &cobra.Command{
 	Use:   "longpress [x,y]",
@@ -177,6 +180,45 @@ var ioSwipeCmd = &cobra.Command{
 	},
 }
 
+var ioPinchCmd = &cobra.Command{
+	Use:   "pinch [x,y]",
+	Short: "Pinch on a device screen with two fingers to zoom in or out",
+	Long:  `Sends a two-finger pinch to the specified device, centered at the given x,y coordinates or at the center of the screen when omitted. "--direction out" spreads the fingers apart (zoom in); "--direction in" brings them together (zoom out). Coordinates should be provided as a single string "x,y".`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		req := commands.PinchRequest{
+			DeviceID:  deviceId,
+			Direction: pinchDirection,
+			Distance:  pinchDistance,
+			Duration:  pinchDuration,
+		}
+
+		if len(args) == 1 {
+			coordsStr := args[0]
+			parts := strings.Split(coordsStr, ",")
+			if len(parts) != 2 {
+				response := commands.NewErrorResponse(fmt.Errorf("invalid coordinate format. Expected 'x,y', got '%s'", coordsStr))
+				printJson(response)
+				return fmt.Errorf("%s", response.Error)
+			}
+
+			x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
+			y, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
+
+			if errX != nil || errY != nil {
+				response := commands.NewErrorResponse(fmt.Errorf("invalid coordinate values. x and y must be integers. Got x='%s', y='%s'", parts[0], parts[1]))
+				printJson(response)
+				return fmt.Errorf("%s", response.Error)
+			}
+
+			req.X = x
+			req.Y = y
+		}
+
+		return runViaDaemon("cli.io.pinch", req)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(ioCmd)
 
@@ -187,6 +229,7 @@ func init() {
 	ioCmd.AddCommand(ioTextCmd)
 	ioCmd.AddCommand(ioKeysCmd)
 	ioCmd.AddCommand(ioSwipeCmd)
+	ioCmd.AddCommand(ioPinchCmd)
 
 	// io command flags
 	ioTapCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to tap on")
@@ -197,4 +240,9 @@ func init() {
 	ioTextCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to send keys to")
 	ioKeysCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to press keys on")
 	ioSwipeCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to swipe on")
+	ioPinchCmd.Flags().StringVar(&deviceId, "device", "", "ID of the device to pinch on")
+	ioPinchCmd.Flags().StringVar(&pinchDirection, "direction", "", "\"in\" to zoom out or \"out\" to zoom in (required)")
+	ioPinchCmd.Flags().IntVar(&pinchDistance, "distance", 200, "pixels each finger travels")
+	ioPinchCmd.Flags().IntVar(&pinchDuration, "duration", 300, "duration of the finger movement in milliseconds")
+	cobra.CheckErr(ioPinchCmd.MarkFlagRequired("direction"))
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -87,7 +87,7 @@ INPUT/OUTPUT:
   # Swipe from one point to another
   mobilecli io swipe --device <device-id> 100,200,300,400
 
-  # Pinch to zoom in (out) or out (in) around a point, or the screen center if omitted
+  # Pinch around a point (screen center if omitted): --direction out zooms in, --direction in zooms out
   mobilecli io pinch --device <device-id> 500,800 --direction out
 
   # Press hardware button (HOME, VOLUME_UP, VOLUME_DOWN, POWER)

--- a/cli/root.go
+++ b/cli/root.go
@@ -87,6 +87,9 @@ INPUT/OUTPUT:
   # Swipe from one point to another
   mobilecli io swipe --device <device-id> 100,200,300,400
 
+  # Pinch to zoom in (out) or out (in) around a point, or the screen center if omitted
+  mobilecli io pinch --device <device-id> 500,800 --direction out
+
   # Press hardware button (HOME, VOLUME_UP, VOLUME_DOWN, POWER)
   mobilecli io button --device <device-id> HOME
 

--- a/commands/input.go
+++ b/commands/input.go
@@ -54,6 +54,75 @@ type SwipeRequest struct {
 	Duration int    `json:"duration"`
 }
 
+// PinchRequest represents the parameters for a pinch command. X,Y is the
+// center of the pinch; both zero means the center of the screen.
+type PinchRequest struct {
+	DeviceID  string `json:"deviceId"`
+	X         int    `json:"x"`
+	Y         int    `json:"y"`
+	Direction string `json:"direction"`
+	Distance  int    `json:"distance"`
+	Duration  int    `json:"duration"`
+}
+
+const (
+	PinchDirectionIn  = "in"
+	PinchDirectionOut = "out"
+
+	defaultPinchDistance   = 200
+	defaultPinchDurationMs = 300
+
+	// pinchStartGap is how far from the center each finger touches down (or
+	// lifts, for "in"), so the two fingers never share a point.
+	pinchStartGap = 30
+
+	// pinchPressHoldMs keeps both fingers still for a few frames before they
+	// travel, the way a real pinch begins.
+	pinchPressHoldMs = 50
+)
+
+// pinchActions lays two fingers on the horizontal line through (x, y), each
+// pinchStartGap from the center, and moves them distance pixels away from it
+// ("out", zooms in) or toward it ("in", zooms out) over duration milliseconds.
+// Each finger is one complete, contiguous pointer sequence with its own Button,
+// which is what devicekit.ConvertActions expects; the agents run both fingers
+// at the same time.
+func pinchActions(x, y int, direction string, distance, duration int) ([]devicekit.TapAction, error) {
+	if distance <= 0 {
+		distance = defaultPinchDistance
+	}
+	if duration <= 0 {
+		duration = defaultPinchDurationMs
+	}
+
+	near, far := pinchStartGap, pinchStartGap+distance
+	var startOffset, endOffset int
+	switch direction {
+	case PinchDirectionOut:
+		startOffset, endOffset = near, far
+	case PinchDirectionIn:
+		startOffset, endOffset = far, near
+	default:
+		return nil, fmt.Errorf("direction must be %q or %q, got %q", PinchDirectionIn, PinchDirectionOut, direction)
+	}
+
+	if x-far < 0 || y < 0 {
+		return nil, fmt.Errorf("pinch centered at (%d,%d) with distance %d does not fit on screen: the left finger would reach x=%d", x, y, distance, x-far)
+	}
+
+	var actions []devicekit.TapAction
+	for finger, side := range []int{-1, +1} {
+		actions = append(actions,
+			devicekit.TapAction{Type: "pointerMove", X: x + side*startOffset, Y: y, Button: finger},
+			devicekit.TapAction{Type: "pointerDown", Button: finger},
+			devicekit.TapAction{Type: "pause", Duration: pinchPressHoldMs, Button: finger},
+			devicekit.TapAction{Type: "pointerMove", X: x + side*endOffset, Y: y, Duration: duration, Button: finger},
+			devicekit.TapAction{Type: "pointerUp", Button: finger},
+		)
+	}
+	return actions, nil
+}
+
 // TapCommand performs a tap operation on the specified device
 func TapCommand(req TapRequest) *CommandResponse {
 	if req.Ref == "" && (req.X < 0 || req.Y < 0) {
@@ -245,6 +314,58 @@ func GestureCommand(req GestureRequest) *CommandResponse {
 	return NewSuccessResponse(MessageResult{
 		Message: fmt.Sprintf("Performed gesture on device %s with %d actions", targetDevice.ID(), len(req.Actions)),
 	})
+}
+
+// PinchCommand performs a two-finger pinch on the specified device
+func PinchCommand(req PinchRequest) *CommandResponse {
+	if req.Direction != PinchDirectionIn && req.Direction != PinchDirectionOut {
+		return NewErrorResponse(fmt.Errorf("direction must be %q or %q, got %q", PinchDirectionIn, PinchDirectionOut, req.Direction))
+	}
+
+	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
+	}
+
+	err = targetDevice.StartAgent(devices.StartAgentConfig{
+		Hook: GetShutdownHook(),
+	})
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+	}
+
+	x, y := req.X, req.Y
+	if x == 0 && y == 0 {
+		x, y, err = screenCenter(targetDevice)
+		if err != nil {
+			return NewErrorResponse(err)
+		}
+	}
+
+	actions, err := pinchActions(x, y, req.Direction, req.Distance, req.Duration)
+	if err != nil {
+		return NewErrorResponse(err)
+	}
+
+	err = targetDevice.Gesture(actions)
+	if err != nil {
+		return NewErrorResponse(fmt.Errorf("failed to pinch on device %s: %v", targetDevice.ID(), err))
+	}
+
+	return NewSuccessResponse(MessageResult{
+		Message: fmt.Sprintf("Pinched %s on device %s around (%d,%d)", req.Direction, targetDevice.ID(), x, y),
+	})
+}
+
+func screenCenter(device devices.ControllableDevice) (int, int, error) {
+	info, err := device.Info()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get screen size of device %s: %v", device.ID(), err)
+	}
+	if info.ScreenSize == nil {
+		return 0, 0, fmt.Errorf("device %s did not report a screen size; pass x,y explicitly", device.ID())
+	}
+	return info.ScreenSize.Width / 2, info.ScreenSize.Height / 2, nil
 }
 
 // SwipeCommand performs a swipe operation on the specified device

--- a/commands/input.go
+++ b/commands/input.go
@@ -87,6 +87,11 @@ const (
 // Each finger is one complete, contiguous pointer sequence with its own Button,
 // which is what devicekit.ConvertActions expects; the agents run both fingers
 // at the same time.
+//
+// Like every other io command, this rejects negative coordinates and leaves
+// the far edges to the device: the screen size mobilecli can read is the
+// natural-orientation one, so checking against it would refuse valid pinches
+// on a rotated screen.
 func pinchActions(x, y int, direction string, distance, duration int) ([]devicekit.TapAction, error) {
 	if distance <= 0 {
 		distance = defaultPinchDistance
@@ -106,8 +111,11 @@ func pinchActions(x, y int, direction string, distance, duration int) ([]devicek
 		return nil, fmt.Errorf("direction must be %q or %q, got %q", PinchDirectionIn, PinchDirectionOut, direction)
 	}
 
-	if x-far < 0 || y < 0 {
-		return nil, fmt.Errorf("pinch centered at (%d,%d) with distance %d does not fit on screen: the left finger would reach x=%d", x, y, distance, x-far)
+	if y < 0 {
+		return nil, fmt.Errorf("pinch center y must be non-negative, got %d", y)
+	}
+	if x-far < 0 {
+		return nil, fmt.Errorf("pinch centered at (%d,%d) with distance %d would put the left finger at x=%d, past the left edge", x, y, distance, x-far)
 	}
 
 	var actions []devicekit.TapAction

--- a/commands/pinch_test.go
+++ b/commands/pinch_test.go
@@ -87,6 +87,7 @@ func TestPinchListsEachFingerContiguously(t *testing.T) {
 	converted := devicekit.ConvertActions(actions)
 	require.Len(t, converted, 6)
 	assert.Equal(t, []string{"press", "move", "release", "press", "move", "release"}, actionTypes(converted))
+	assert.Equal(t, []int{0, 0, 0, 1, 1, 1}, actionButtons(converted), "the finger index survives conversion")
 }
 
 func actionTypes(actions []devicekit.GestureAction) []string {
@@ -97,16 +98,30 @@ func actionTypes(actions []devicekit.GestureAction) []string {
 	return types
 }
 
+func actionButtons(actions []devicekit.GestureAction) []int {
+	buttons := make([]int, len(actions))
+	for i, a := range actions {
+		buttons[i] = a.Button
+	}
+	return buttons
+}
+
 func TestPinchRejectsUnknownDirection(t *testing.T) {
 	_, err := pinchActions(640, 1428, "sideways", 200, 300)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "direction")
 }
 
-func TestPinchRejectsAFingerThatWouldLeaveTheScreen(t *testing.T) {
+func TestPinchRejectsAFingerThatWouldCrossTheLeftEdge(t *testing.T) {
 	_, err := pinchActions(100, 1428, PinchDirectionIn, 200, 300)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not fit on screen")
+	assert.Contains(t, err.Error(), "left finger at x=-130")
+}
+
+func TestPinchRejectsANegativeCenterY(t *testing.T) {
+	_, err := pinchActions(640, -1, PinchDirectionOut, 200, 300)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "y must be non-negative")
 }
 
 func TestPinchCommandNamesTheDirectionBeforeLookingForADevice(t *testing.T) {

--- a/commands/pinch_test.go
+++ b/commands/pinch_test.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/mobile-next/mobilecli/devices/devicekit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const pointerMove = "pointerMove"
+
+// fingerPath returns the x coordinates a finger touches down at and lifts from.
+func fingerPath(t *testing.T, actions []devicekit.TapAction, finger int) (startX, endX int) {
+	t.Helper()
+	var moves []devicekit.TapAction
+	for _, a := range actions {
+		if a.Button == finger && a.Type == pointerMove {
+			moves = append(moves, a)
+		}
+	}
+	require.Len(t, moves, 2, "finger %d should position once and drag once", finger)
+	return moves[0].X, moves[1].X
+}
+
+func TestPinchOutSpreadsFingersAwayFromTheCenter(t *testing.T) {
+	actions, err := pinchActions(640, 1428, PinchDirectionOut, 200, 300)
+	require.NoError(t, err)
+
+	leftStart, leftEnd := fingerPath(t, actions, 0)
+	rightStart, rightEnd := fingerPath(t, actions, 1)
+	assert.Equal(t, 610, leftStart)
+	assert.Equal(t, 410, leftEnd)
+	assert.Equal(t, 670, rightStart)
+	assert.Equal(t, 870, rightEnd)
+
+	for _, a := range actions {
+		if a.Type == pointerMove {
+			assert.Equal(t, 1428, a.Y, "fingers stay on the horizontal line through the center")
+		}
+	}
+}
+
+func TestPinchInBringsFingersTowardTheCenter(t *testing.T) {
+	actions, err := pinchActions(640, 1428, PinchDirectionIn, 200, 300)
+	require.NoError(t, err)
+
+	leftStart, leftEnd := fingerPath(t, actions, 0)
+	rightStart, rightEnd := fingerPath(t, actions, 1)
+	assert.Equal(t, 410, leftStart)
+	assert.Equal(t, 610, leftEnd)
+	assert.Equal(t, 870, rightStart)
+	assert.Equal(t, 670, rightEnd)
+}
+
+func TestPinchAppliesDefaultDistanceAndDuration(t *testing.T) {
+	actions, err := pinchActions(640, 1428, PinchDirectionOut, 0, 0)
+	require.NoError(t, err)
+
+	leftStart, leftEnd := fingerPath(t, actions, 0)
+	assert.Equal(t, defaultPinchDistance, leftStart-leftEnd)
+
+	for _, a := range actions {
+		if a.Type == pointerMove && a.Duration != 0 {
+			assert.Equal(t, defaultPinchDurationMs, a.Duration)
+		}
+	}
+}
+
+func TestPinchListsEachFingerContiguously(t *testing.T) {
+	actions, err := pinchActions(640, 1428, PinchDirectionOut, 200, 300)
+	require.NoError(t, err)
+	require.Len(t, actions, 10)
+
+	// devicekit.ConvertActions is stateful per sequence, so finger 1 must not
+	// start until finger 0 has lifted
+	for i, a := range actions[:5] {
+		assert.Equal(t, 0, a.Button, "action %d belongs to finger 0", i)
+	}
+	for i, a := range actions[5:] {
+		assert.Equal(t, 1, a.Button, "action %d belongs to finger 1", i+5)
+	}
+	assert.Equal(t, "pointerUp", actions[4].Type)
+	assert.Equal(t, pointerMove, actions[5].Type)
+	assert.Equal(t, "pointerDown", actions[6].Type)
+
+	converted := devicekit.ConvertActions(actions)
+	require.Len(t, converted, 6)
+	assert.Equal(t, []string{"press", "move", "release", "press", "move", "release"}, actionTypes(converted))
+}
+
+func actionTypes(actions []devicekit.GestureAction) []string {
+	types := make([]string, len(actions))
+	for i, a := range actions {
+		types[i] = a.Type
+	}
+	return types
+}
+
+func TestPinchRejectsUnknownDirection(t *testing.T) {
+	_, err := pinchActions(640, 1428, "sideways", 200, 300)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "direction")
+}
+
+func TestPinchRejectsAFingerThatWouldLeaveTheScreen(t *testing.T) {
+	_, err := pinchActions(100, 1428, PinchDirectionIn, 200, 300)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not fit on screen")
+}
+
+func TestPinchCommandNamesTheDirectionBeforeLookingForADevice(t *testing.T) {
+	resp := PinchCommand(PinchRequest{DeviceID: "__nope__", Direction: "sideways"})
+	require.Equal(t, "error", resp.Status)
+	assert.Contains(t, resp.Error, "direction")
+	assert.NotContains(t, resp.Error, "__nope__")
+}

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -66,6 +66,7 @@ func CLIRegistry() map[string]CLIHandler {
 		"cli.io.text":                adapt(TextCommand),
 		"cli.io.keys":                adapt(KeysCommand),
 		"cli.io.swipe":               adapt(SwipeCommand),
+		"cli.io.pinch":               adapt(PinchCommand),
 		"cli.io.gesture":             adapt(GestureCommand),
 		"cli.io.clipboard.get":       adapt(ClipboardGetCommand),
 		"cli.io.clipboard.set":       adapt(ClipboardSetCommand),

--- a/commands/registry_test.go
+++ b/commands/registry_test.go
@@ -41,7 +41,7 @@ func TestCLIRegistryCoversEveryCLIMethod(t *testing.T) {
 		"cli.apps.launch", "cli.apps.terminate", "cli.apps.list", "cli.apps.install", "cli.apps.uninstall",
 		"cli.apps.clear", "cli.apps.foreground", "cli.apps.path",
 		"cli.io.tap", "cli.io.longpress", "cli.io.button", "cli.io.text", "cli.io.keys", "cli.io.swipe",
-		"cli.io.gesture", "cli.io.clipboard.get", "cli.io.clipboard.set",
+		"cli.io.pinch", "cli.io.gesture", "cli.io.clipboard.get", "cli.io.clipboard.set",
 		"cli.fs.push", "cli.fs.pull", "cli.fs.ls", "cli.fs.mkdir", "cli.fs.rm",
 		"cli.webview.list", "cli.webview.goto", "cli.webview.reload", "cli.webview.back", "cli.webview.forward",
 		"cli.webview.eval", "cli.webview.wait", "cli.webview.content",

--- a/devices/android.go
+++ b/devices/android.go
@@ -520,40 +520,14 @@ func (d *AndroidDevice) SetClipboard(text string) error {
 	return err
 }
 
-// Gesture performs a sequence of touch actions on the Android device
+// Gesture performs a multi-finger touch sequence through the on-device server,
+// which replays it as timed MotionEvents via UiAutomation. Actions are grouped
+// by Button (finger index) and converted exactly as for devicekit-ios, so both
+// platforms take one gesture contract; fingers move at the same time, which is
+// what makes a pinch possible here.
 func (d *AndroidDevice) Gesture(actions []devicekit.TapAction) error {
-
-	x := 0
-	y := 0
-
-	for _, action := range actions {
-		var cmd []string
-
-		if action.Type == "pause" {
-			time.Sleep(time.Duration(action.Duration) * time.Millisecond)
-			continue
-		}
-
-		switch action.Type {
-		case "pointerDown":
-			cmd = []string{"shell", "input", "touchscreen", "motionevent", "down", fmt.Sprintf("%d", x), fmt.Sprintf("%d", y)}
-		case "pointerMove":
-			x = action.X
-			y = action.Y
-			cmd = []string{"shell", "input", "touchscreen", "motionevent", "move", fmt.Sprintf("%d", action.X), fmt.Sprintf("%d", action.Y)}
-		case "pointerUp":
-			cmd = []string{"shell", "input", "touchscreen", "motionevent", "up", fmt.Sprintf("%d", x), fmt.Sprintf("%d", y)}
-		default:
-			return fmt.Errorf("unsupported gesture action type: %s", action.Type)
-		}
-
-		_, err := d.runAdbCommand(cmd...)
-		if err != nil {
-			return fmt.Errorf("failed to execute gesture action %s: %v", action.Type, err)
-		}
-	}
-
-	return nil
+	_, err := d.serverRequest("device.io.gesture", map[string]any{"actions": devicekit.ConvertActions(actions)})
+	return err
 }
 
 func parseAdbDevicesOutput(output string) []ControllableDevice {

--- a/devices/android.go
+++ b/devices/android.go
@@ -33,6 +33,25 @@ const androidDiscoveryGetpropTimeout = 5 * time.Second
 const androidDexPath = "/data/local/tmp/mobilecli.dex"
 
 // AndroidDevice implements the ControllableDevice interface for Android devices
+// Parameter shapes for the DeviceServer methods this file calls; the JSON keys
+// are the ones agents/android/java/DeviceServer.java reads.
+type screenshotParams struct {
+	Format      string                   `json:"format"`
+	Quality     int                      `json:"quality"`
+	Scale       float64                  `json:"scale"`
+	MaxSize     int                      `json:"maxSize"`
+	Clip        *types.ScreenElementRect `json:"clip,omitempty"`
+	ScreenWidth int                      `json:"screenWidth,omitempty"`
+}
+
+type clipboardSetParams struct {
+	Text string `json:"text"`
+}
+
+type gestureParams struct {
+	Actions []devicekit.GestureAction `json:"actions"`
+}
+
 type AndroidDevice struct {
 	id          string
 	name        string
@@ -284,17 +303,15 @@ func (d *AndroidDevice) takeScreenshotWithDex(opts ScreenshotOptions) ([]byte, e
 
 	utils.Verbose("taking screenshot on-device via mobilecli.dex")
 
-	params := map[string]any{
-		"format":  format,
-		"quality": opts.Quality,
-		"scale":   opts.Scale,
-		"maxSize": opts.MaxSize,
+	params := screenshotParams{
+		Format:  format,
+		Quality: opts.Quality,
+		Scale:   opts.Scale,
+		MaxSize: opts.MaxSize,
 	}
 	if opts.Clip != nil {
-		params["clip"] = map[string]any{
-			"x": opts.Clip.X, "y": opts.Clip.Y, "width": opts.Clip.Width, "height": opts.Clip.Height,
-		}
-		params["screenWidth"] = opts.ScreenWidthPoints
+		params.Clip = opts.Clip
+		params.ScreenWidth = opts.ScreenWidthPoints
 	}
 
 	raw, err := d.serverRequest("device.screenshot", params)
@@ -516,7 +533,7 @@ func (d *AndroidDevice) SetClipboard(text string) error {
 		_, err := d.serverRequest("device.clipboard.clear", nil)
 		return err
 	}
-	_, err := d.serverRequest("device.clipboard.set", map[string]any{"text": text})
+	_, err := d.serverRequest("device.clipboard.set", clipboardSetParams{Text: text})
 	return err
 }
 
@@ -526,7 +543,7 @@ func (d *AndroidDevice) SetClipboard(text string) error {
 // platforms take one gesture contract; fingers move at the same time, which is
 // what makes a pinch possible here.
 func (d *AndroidDevice) Gesture(actions []devicekit.TapAction) error {
-	_, err := d.serverRequest("device.io.gesture", map[string]any{"actions": devicekit.ConvertActions(actions)})
+	_, err := d.serverRequest("device.io.gesture", gestureParams{Actions: devicekit.ConvertActions(actions)})
 	return err
 }
 

--- a/devices/android_device_server.go
+++ b/devices/android_device_server.go
@@ -13,6 +13,12 @@ import (
 	"github.com/mobile-next/mobilecli/utils"
 )
 
+// dumpUiParams is what DeviceServer's device.dump.ui reads.
+type dumpUiParams struct {
+	WaitUntilIdle int  `json:"waitUntilIdle"`
+	Full          bool `json:"full"`
+}
+
 // deviceServerClass is the persistent on-device server (agents/android/java/DeviceServer.java).
 const deviceServerClass = "com.mobilenext.mobilecli.DeviceServer"
 
@@ -121,7 +127,7 @@ func embeddedDexSHA256() string {
 
 // serverRequest sends a JSON-RPC call to the persistent DeviceServer, starting
 // it if needed.
-func (d *AndroidDevice) serverRequest(method string, params map[string]any) (json.RawMessage, error) {
+func (d *AndroidDevice) serverRequest(method string, params any) (json.RawMessage, error) {
 	port, err := d.ensureDeviceServerReady()
 	if err != nil {
 		return nil, err
@@ -134,7 +140,7 @@ func (d *AndroidDevice) serverRequest(method string, params map[string]any) (jso
 func (d *AndroidDevice) dumpUiNodes(opts DumpOptions) ([]uiNode, error) {
 	startTime := time.Now()
 
-	raw, err := d.serverRequest("device.dump.ui", map[string]any{"waitUntilIdle": dumpUiWaitUntilIdleMs, "full": opts.Full})
+	raw, err := d.serverRequest("device.dump.ui", dumpUiParams{WaitUntilIdle: dumpUiWaitUntilIdleMs, Full: opts.Full})
 	if err != nil {
 		return nil, fmt.Errorf("device server dump.ui: %w", err)
 	}

--- a/devices/android_location.go
+++ b/devices/android_location.go
@@ -7,6 +7,12 @@ import (
 	"github.com/mobile-next/mobilecli/utils"
 )
 
+// locationParams is what DeviceServer's device.location.set reads.
+type locationParams struct {
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
+}
+
 // shellPackage is the package the DeviceServer (app_process) is attributed
 // to, and therefore the one the mock_location appop has to be granted to
 const shellPackage = "com.android.shell"
@@ -76,7 +82,7 @@ func (d *AndroidDevice) startMockLocation(lat, lon float64) error {
 		return fmt.Errorf("grant mock_location appop: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
-	if _, err := d.serverRequest("device.location.set", map[string]any{"lat": lat, "lon": lon}); err != nil {
+	if _, err := d.serverRequest("device.location.set", locationParams{Lat: lat, Lon: lon}); err != nil {
 		if revokeErr := d.revokeMockLocationAppop(); revokeErr != nil {
 			utils.Verbose("failed to revoke mock_location appop after a failed start: %v", revokeErr)
 		}

--- a/devices/android_rpc.go
+++ b/devices/android_rpc.go
@@ -18,23 +18,24 @@ import (
 
 const defaultAgentTimeout = 10 * time.Second
 
+// jsonRPCRequest is the envelope every agent call is wrapped in. Params is
+// whatever shape the method takes, typically a small struct declared next to
+// its caller; nil means the method takes none and the field is left out.
+type jsonRPCRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      string `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
 // agentRequest sends a JSON-RPC 2.0 request to the agent over HTTP and returns
 // the result field from the response.
-func agentRequest(port int, method string, params map[string]any) (json.RawMessage, error) {
+func agentRequest(port int, method string, params any) (json.RawMessage, error) {
 	return agentRequestWithTimeout(port, method, params, defaultAgentTimeout)
 }
 
-func agentRequestWithTimeout(port int, method string, params map[string]any, timeout time.Duration) (json.RawMessage, error) {
-	body := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "1",
-		"method":  method,
-	}
-	if len(params) > 0 {
-		body["params"] = params
-	}
-
-	payload, err := json.Marshal(body)
+func agentRequestWithTimeout(port int, method string, params any, timeout time.Duration) (json.RawMessage, error) {
+	payload, err := json.Marshal(jsonRPCRequest{JSONRPC: "2.0", ID: "1", Method: method, Params: params})
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}

--- a/devices/android_rpc_test.go
+++ b/devices/android_rpc_test.go
@@ -1,0 +1,70 @@
+package devices
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mobile-next/mobilecli/devices/devicekit"
+	"github.com/mobile-next/mobilecli/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wireKeys returns the top-level JSON keys a value marshals to.
+func wireKeys(t *testing.T, v any) []string {
+	t.Helper()
+	payload, err := json.Marshal(v)
+	require.NoError(t, err)
+	var object map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &object))
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func TestAgentRequestLeavesParamsOutWhenThereAreNone(t *testing.T) {
+	payload, err := json.Marshal(jsonRPCRequest{JSONRPC: "2.0", ID: "1", Method: "device.version"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"jsonrpc":"2.0","id":"1","method":"device.version"}`, string(payload))
+}
+
+func TestGestureParamsCarryEachActionWithItsFinger(t *testing.T) {
+	actions := devicekit.ConvertActions([]devicekit.TapAction{
+		{Type: "pointerMove", X: 610, Y: 1428, Button: 0},
+		{Type: "pointerDown", Button: 0},
+		{Type: "pointerUp", Button: 0},
+		{Type: "pointerMove", X: 670, Y: 1428, Button: 1},
+		{Type: "pointerDown", Button: 1},
+		{Type: "pointerUp", Button: 1},
+	})
+
+	payload, err := json.Marshal(jsonRPCRequest{JSONRPC: "2.0", ID: "1", Method: "device.io.gesture", Params: gestureParams{Actions: actions}})
+	require.NoError(t, err)
+
+	var wire struct {
+		Params struct {
+			Actions []map[string]any `json:"actions"`
+		} `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	require.Len(t, wire.Params.Actions, 4)
+
+	assert.Equal(t, "press", wire.Params.Actions[0]["type"])
+	assert.Equal(t, float64(0), wire.Params.Actions[0]["button"])
+	assert.Equal(t, "press", wire.Params.Actions[2]["type"])
+	assert.Equal(t, float64(1), wire.Params.Actions[2]["button"])
+	assert.Equal(t, float64(670), wire.Params.Actions[2]["x"])
+}
+
+func TestScreenshotParamsUseTheKeysDeviceServerReads(t *testing.T) {
+	plain := screenshotParams{Format: "png", Quality: 90, Scale: 1, MaxSize: 0}
+	assert.ElementsMatch(t, []string{"format", "quality", "scale", "maxSize"}, wireKeys(t, plain))
+
+	clipped := plain
+	clipped.Clip = &types.ScreenElementRect{X: 1, Y: 2, Width: 3, Height: 4}
+	clipped.ScreenWidth = 412
+	assert.ElementsMatch(t, []string{"format", "quality", "scale", "maxSize", "clip", "screenWidth"}, wireKeys(t, clipped))
+	assert.ElementsMatch(t, []string{"x", "y", "width", "height"}, wireKeys(t, clipped.Clip))
+}

--- a/devices/devicekit/gesture.go
+++ b/devices/devicekit/gesture.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 )
 
-type gestureAction struct {
+// GestureAction is one step of one finger in the contract both device agents
+// speak: devicekit-ios's device.io.gesture and the Android DeviceServer's.
+// Duration is in seconds; Button is the finger index.
+type GestureAction struct {
 	Type     string  `json:"type"`
 	Duration float64 `json:"duration"`
 	X        float64 `json:"x"`
@@ -13,11 +16,15 @@ type gestureAction struct {
 	Button   int     `json:"button"`
 }
 
-// convertActions converts WDA-style TapActions to devicekit-ios gesture actions.
+// ConvertActions converts WDA-style TapActions to the agents' gesture actions.
 // WDA uses: pointerMove (position) -> pointerDown -> pointerMove (drag) -> pointerUp
-// devicekit-ios uses: press (with position) -> move -> release
-func convertActions(actions []TapAction) []gestureAction {
-	var result []gestureAction
+// The agents use: press (with position) -> move -> release
+//
+// The conversion is stateful per sequence, not per finger: a multi-finger
+// gesture must list each finger's actions contiguously (all of Button 0, then
+// all of Button 1), never interleaved.
+func ConvertActions(actions []TapAction) []GestureAction {
+	var result []GestureAction
 	pressed := false
 	hasPendingPos := false
 	var pendingX, pendingY float64
@@ -32,7 +39,7 @@ func convertActions(actions []TapAction) []gestureAction {
 				hasPendingPos = true
 			} else {
 				// pointerMove after pointerDown is a drag
-				result = append(result, gestureAction{
+				result = append(result, GestureAction{
 					Type:     "move",
 					Duration: float64(a.Duration) / 1000.0,
 					X:        float64(a.X),
@@ -47,7 +54,7 @@ func convertActions(actions []TapAction) []gestureAction {
 				x, y = pendingX, pendingY
 				hasPendingPos = false
 			}
-			result = append(result, gestureAction{
+			result = append(result, GestureAction{
 				Type:     "press",
 				Duration: float64(a.Duration) / 1000.0,
 				X:        x,
@@ -61,7 +68,7 @@ func convertActions(actions []TapAction) []gestureAction {
 				last := result[len(result)-1]
 				x, y = last.X, last.Y
 			}
-			result = append(result, gestureAction{
+			result = append(result, GestureAction{
 				Type:     "release",
 				Duration: float64(a.Duration) / 1000.0,
 				X:        x,
@@ -80,7 +87,7 @@ func convertActions(actions []TapAction) []gestureAction {
 
 func (c *DeviceKitClient) Gesture(actions []TapAction) error {
 	params := map[string]any{
-		"actions": convertActions(actions),
+		"actions": ConvertActions(actions),
 	}
 
 	_, err := c.CallRPC("device.io.gesture", params)

--- a/devices/devicekit/gesture_test.go
+++ b/devices/devicekit/gesture_test.go
@@ -1,0 +1,35 @@
+package devicekit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertActionsKeepsTwoContiguousFingersApart(t *testing.T) {
+	actions := []TapAction{
+		{Type: "pointerMove", X: 100, Y: 500, Button: 0},
+		{Type: "pointerDown", Button: 0},
+		{Type: "pause", Duration: 50, Button: 0},
+		{Type: "pointerMove", X: 10, Y: 500, Duration: 300, Button: 0},
+		{Type: "pointerUp", Button: 0},
+		{Type: "pointerMove", X: 200, Y: 500, Button: 1},
+		{Type: "pointerDown", Button: 1},
+		{Type: "pointerMove", X: 290, Y: 500, Duration: 300, Button: 1},
+		{Type: "pointerUp", Button: 1},
+	}
+
+	converted := ConvertActions(actions)
+	require.Len(t, converted, 6)
+
+	assert.Equal(t, GestureAction{Type: "press", X: 100, Y: 500, Duration: 0.05, Button: 0}, converted[0])
+	assert.Equal(t, GestureAction{Type: "move", X: 10, Y: 500, Duration: 0.3, Button: 0}, converted[1])
+	assert.Equal(t, GestureAction{Type: "release", X: 10, Y: 500, Button: 0}, converted[2])
+
+	// the second finger starts a fresh press at its own position, not the
+	// first finger's last point
+	assert.Equal(t, GestureAction{Type: "press", X: 200, Y: 500, Button: 1}, converted[3])
+	assert.Equal(t, GestureAction{Type: "move", X: 290, Y: 500, Duration: 0.3, Button: 1}, converted[4])
+	assert.Equal(t, GestureAction{Type: "release", X: 290, Y: 500, Button: 1}, converted[5])
+}

--- a/devices/ios_device_agent.go
+++ b/devices/ios_device_agent.go
@@ -65,11 +65,11 @@ func setCachedDeviceAgentPort(udid string, port int) {
 // agentCall ensures the agent is ready and makes a JSON-RPC call to it. This is
 // the single seam every device-agent feature uses; it also drops the cached
 // port on failure so a dead agent is re-injected on the next call.
-func (d *IOSDevice) agentCall(method string, params map[string]any) (json.RawMessage, error) {
+func (d *IOSDevice) agentCall(method string, params any) (json.RawMessage, error) {
 	return d.agentCallWithTimeout(method, params, defaultAgentTimeout)
 }
 
-func (d *IOSDevice) agentCallWithTimeout(method string, params map[string]any, timeout time.Duration) (json.RawMessage, error) {
+func (d *IOSDevice) agentCallWithTimeout(method string, params any, timeout time.Duration) (json.RawMessage, error) {
 	port, err := d.ensureIOSDeviceAgentReady()
 	if err != nil {
 		return nil, err

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -545,6 +545,69 @@
       }
     },
     {
+      "name": "device.io.pinch",
+      "summary": "Perform two-finger pinch gesture",
+      "description": "Performs a two-finger pinch centered at (x, y) on the device screen. Direction \"out\" spreads the fingers apart to zoom in, \"in\" brings them together to zoom out. Omitting x and y pinches around the center of the screen.",
+      "params": [
+        {
+          "name": "deviceId",
+          "description": "ID of the target device",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "direction",
+          "description": "\"in\" to zoom out or \"out\" to zoom in",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "enum": ["in", "out"]
+          }
+        },
+        {
+          "name": "x",
+          "description": "X coordinate of the pinch center, defaults to the screen center",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "y",
+          "description": "Y coordinate of the pinch center, defaults to the screen center",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "distance",
+          "description": "Pixels each finger travels, defaults to 200",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "duration",
+          "description": "Duration of the finger movement in milliseconds, defaults to 300",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "result": {
+        "name": "success",
+        "description": "Operation result",
+        "schema": {
+          "$ref": "#/components/schemas/SuccessResult"
+        }
+      }
+    },
+    {
       "name": "device.info",
       "summary": "Get device information",
       "description": "Returns detailed information about the specified device",

--- a/docs/openrpc.md
+++ b/docs/openrpc.md
@@ -32,6 +32,7 @@ JSON-RPC API for mobile device automation and control
 - [device.io.longpress](#deviceiolongpress)
 - [device.io.orientation.get](#deviceioorientationget)
 - [device.io.orientation.set](#deviceioorientationset)
+- [device.io.pinch](#deviceiopinch)
 - [device.io.swipe](#deviceioswipe)
 - [device.io.tap](#deviceiotap)
 - [device.io.text](#deviceiotext)
@@ -534,7 +535,8 @@ UI hierarchy data
   "method": "device.dump.ui",
   "params": {
     "deviceId": "string",
-    "format": "json"
+    "format": "json",
+    "full": false
   },
   "id": 1
 }
@@ -959,6 +961,48 @@ Operation result
   "params": {
     "deviceId": "string",
     "orientation": "string"
+  },
+  "id": 1
+}
+```
+
+
+### device.io.pinch
+
+**Perform two-finger pinch gesture**
+
+Performs a two-finger pinch centered at (x, y) on the device screen. Direction "out" spreads the fingers apart to zoom in, "in" brings them together to zoom out. Omitting x and y pinches around the center of the screen.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `deviceId` | `string` | ✓ | ID of the target device |
+| `direction` | enum: `in, out` | ✓ | "in" to zoom out or "out" to zoom in |
+| `x` | `integer` |  | X coordinate of the pinch center, defaults to the screen center |
+| `y` | `integer` |  | Y coordinate of the pinch center, defaults to the screen center |
+| `distance` | `integer` |  | Pixels each finger travels, defaults to 200 |
+| `duration` | `integer` |  | Duration of the finger movement in milliseconds, defaults to 300 |
+
+#### Response
+
+**Type:** [`SuccessResult`](#successresult)
+
+Operation result
+
+#### Example Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "device.io.pinch",
+  "params": {
+    "deviceId": "string",
+    "direction": "in",
+    "x": 0,
+    "y": 0,
+    "distance": 0,
+    "duration": 0
   },
   "id": 1
 }

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -24,6 +24,7 @@ func GetMethodRegistry() map[string]HandlerFunc {
 		"device.io.keys":                        handleIoKeys,
 		"device.io.button":                      handleIoButton,
 		"device.io.swipe":                       handleIoSwipe,
+		"device.io.pinch":                       handleIoPinch,
 		"device.clipboard.get":                  handleClipboardGet,
 		"device.clipboard.set":                  handleClipboardSet,
 		"device.io.gesture":                     handleIoGesture,

--- a/server/server.go
+++ b/server/server.go
@@ -443,6 +443,15 @@ type IoSwipeParams struct {
 	Duration int    `json:"duration"`
 }
 
+type IoPinchParams struct {
+	DeviceID  string `json:"deviceId"`
+	X         int    `json:"x"`
+	Y         int    `json:"y"`
+	Direction string `json:"direction"`
+	Distance  int    `json:"distance"`
+	Duration  int    `json:"duration"`
+}
+
 func handleIoTap(params json.RawMessage) (any, error) {
 	if len(params) == 0 {
 		return nil, fmt.Errorf("'params' is required with fields: deviceId, x, y")
@@ -535,6 +544,47 @@ func handleIoSwipe(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.SwipeCommand(req)
+	if response.Status == "error" {
+		return nil, fmt.Errorf("%s", response.Error)
+	}
+
+	return okResponse, nil
+}
+
+func handleIoPinch(params json.RawMessage) (any, error) {
+	if len(params) == 0 {
+		return nil, fmt.Errorf("'params' is required with fields: deviceId, direction, x, y")
+	}
+
+	var ioPinchParams IoPinchParams
+	if err := json.Unmarshal(params, &ioPinchParams); err != nil {
+		return nil, fmt.Errorf("invalid parameters: %w. Expected fields: deviceId, direction, x, y", err)
+	}
+
+	if ioPinchParams.DeviceID == "" {
+		return nil, fmt.Errorf("'deviceId' is required")
+	}
+
+	// direction is checked by presence so a missing field is named, not
+	// reported as an invalid empty value
+	var rawParams map[string]any
+	if err := json.Unmarshal(params, &rawParams); err != nil {
+		return nil, fmt.Errorf("invalid parameters format")
+	}
+	if _, exists := rawParams["direction"]; !exists {
+		return nil, fmt.Errorf("'direction' is required")
+	}
+
+	req := commands.PinchRequest{
+		DeviceID:  ioPinchParams.DeviceID,
+		X:         ioPinchParams.X,
+		Y:         ioPinchParams.Y,
+		Direction: ioPinchParams.Direction,
+		Distance:  ioPinchParams.Distance,
+		Duration:  ioPinchParams.Duration,
+	}
+
+	response := commands.PinchCommand(req)
 	if response.Status == "error" {
 		return nil, fmt.Errorf("%s", response.Error)
 	}

--- a/skills/mobilecli/SKILL.md
+++ b/skills/mobilecli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mobilecli
-description: Run mobile automation, app testing, and interact with iOS and Android devices, simulators, emulators, and apps using the mobilecli CLI tool or JSON-RPC API. Trigger this skill whenever the user wants to list connected devices, boot or shut down simulators/emulators, take mobile screenshots, start screen recordings, send key/touch inputs (tap, text, swipe, hardware buttons), manage apps (install, uninstall, launch, terminate, get foreground app), inspect webviews (query DOM, evaluate JS, navigate), download/upload files on-device, get crash reports, install mobilecli, or allocate and release remote real devices on Mobile Next cloud, even if they don't explicitly name "mobilecli". Requires the mobilecli npm package; the skill installs it if missing.
+description: Run mobile automation, app testing, and interact with iOS and Android devices, simulators, emulators, and apps using the mobilecli CLI tool or JSON-RPC API. Trigger this skill whenever the user wants to list connected devices, boot or shut down simulators/emulators, take mobile screenshots, start screen recordings, send key/touch inputs (tap, text, swipe, pinch, hardware buttons), manage apps (install, uninstall, launch, terminate, get foreground app), inspect webviews (query DOM, evaluate JS, navigate), download/upload files on-device, get crash reports, install mobilecli, or allocate and release remote real devices on Mobile Next cloud, even if they don't explicitly name "mobilecli". Requires the mobilecli npm package; the skill installs it if missing.
 allowed-tools: Bash(mobilecli:*)
 ---
 
@@ -130,6 +130,7 @@ Here is a quick reference table mapping standard user actions to `mobilecli` com
 | **Tap** | `mobilecli io tap @e5` or `mobilecli io tap <x,y>` | Single touch on a ref from `dump ui`, or at coordinates |
 | **Long Press** | `mobilecli io longpress <x,y> --duration <ms>` | Press and hold for a duration |
 | **Swipe** | `mobilecli io swipe <x1,y1,x2,y2>` | Drag from start to end coordinates |
+| **Pinch** | `mobilecli io pinch [x,y] --direction in\|out` | Two-finger zoom out (`in`) or in (`out`), around x,y or the screen center |
 | **Type Text** | `mobilecli io text "<text>"` | Send raw text to the focused field |
 | **Key Press** | `mobilecli io button <BUTTON_NAME>` | Press hardware buttons (e.g. HOME, POWER) |
 | **Read Clipboard** | `mobilecli io clipboard get` | Read text from the device clipboard |

--- a/skills/mobilecli/reference.md
+++ b/skills/mobilecli/reference.md
@@ -95,6 +95,13 @@ All commands support the global `--device <id>` flag to specify the target devic
   # Swipe from x1,y1 to x2,y2
   mobilecli io swipe --device <device-id> 100,600,100,200
   ```
+* **Pinch** (two fingers, zoom):
+  ```bash
+  # Zoom in around 500,800 (fingers spread apart); omit the coordinates to pinch at the screen center
+  mobilecli io pinch --device <device-id> 500,800 --direction out
+  # Zoom out, fingers travel 300px each over 500ms
+  mobilecli io pinch --device <device-id> --direction in --distance 300 --duration 500
+  ```
 * **Send Text**:
   ```bash
   # Types text into the currently focused input field
@@ -232,13 +239,15 @@ For scripts and long-running automation, make HTTP POST requests to the server's
   ```
 
 ### Custom Gestures (JSON-RPC only)
-For complex multi-action interactions (e.g. dragging, pinching, or specific curves) which are not accessible via standard CLI gestures, use the `device.io.gesture` method. This allows you to chain raw pointer motion events.
+For complex multi-action interactions (e.g. dragging, rotating, or specific curves) which are not accessible via standard CLI gestures, use the `device.io.gesture` method. This allows you to chain raw pointer motion events. For a plain zoom, prefer `device.io.pinch` / `mobilecli io pinch`.
 
 Supported actions:
 - `pointerDown`: Touches screen at the current x,y coordinate.
-- `pointerMove`: Moves coordinates to target `x`, `y`.
+- `pointerMove`: Moves coordinates to target `x`, `y` over `duration` (in milliseconds).
 - `pointerUp`: Lifts pointer off screen.
 - `pause`: Sleeps for `duration` (in milliseconds).
+
+Multi-finger gestures: give each action a `button` (finger index, default 0) and list every finger's actions contiguously, one complete `pointerMove` → `pointerDown` → ... → `pointerUp` sequence per finger; the fingers then move at the same time on both iOS and Android.
 
 **Example: Drag-and-Drop Action**
 ```json

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -275,6 +275,7 @@ test.describe('rpc method validation', () => {
 		{method: 'device.io.tap', params: {x: 10, y: 10}},
 		{method: 'device.io.longpress', params: {x: 10, y: 10}},
 		{method: 'device.io.swipe', params: {x1: 1, y1: 2, x2: 3, y2: 4}},
+		{method: 'device.io.pinch', params: {x: 500, y: 500, direction: 'out'}},
 		{method: 'device.io.button', params: {button: 'HOME'}},
 		{method: 'device.io.text', params: {text: 'hello'}},
 		{method: 'device.io.keys', params: {keys: ['a']}},
@@ -309,6 +310,8 @@ test.describe('rpc method validation', () => {
 		{name: 'device.fs.mkdir without remotePath', method: 'device.fs.mkdir', params: {}, mentions: 'remotePath'},
 		{name: 'device.fs.rm without remotePath', method: 'device.fs.rm', params: {}, mentions: 'remotePath'},
 		{name: 'device.io.swipe without x2', method: 'device.io.swipe', params: {x1: 1, y1: 2, y2: 4}, mentions: 'x2'},
+		{name: 'device.io.pinch without direction', method: 'device.io.pinch', params: {x: 500, y: 500}, mentions: 'direction'},
+		{name: 'device.io.pinch with a direction that is not in or out', method: 'device.io.pinch', params: {x: 500, y: 500, direction: 'sideways'}, mentions: 'direction'},
 		{name: 'device.webview.goto without url', method: 'device.webview.goto', params: {id: 'x'}, mentions: 'url'},
 	];
 


### PR DESCRIPTION
Closes mobile-next/mobile-mcp#258 on the mobilecli side.

## What changed

- **Android agent: real multi-finger `device.io.gesture`.** New `agents/android/java/Gestures.java` builds timed `MotionEvent`s with one pointer per finger and injects them through the `DeviceServer`'s `UiAutomation`, the same path uiautomator's own pinch uses. Actions use the contract devicekit-ios already speaks: `{type: press|move|release, x, y, duration, button}`, `button` being the finger index. `AndroidDevice.Gesture` now routes there instead of one `adb shell input motionevent` per action, so fingers move at the same time.
- **`mobilecli io pinch [x,y] --direction in|out [--distance 200] [--duration 300]`.** Two fingers on a horizontal line through the center (screen center when omitted), touching down 30 px either side and travelling `distance` px each. Built once in Go on top of `Gesture`, so iOS and Android share the code. devicekit-ios 0.0.26 already handles multi-finger gestures; no change there.
- **`device.io.pinch`** JSON-RPC twin on the HTTP server, plus openrpc docs, skill reference, registry entry, and tests (`commands/pinch_test.go`, `devices/devicekit/gesture_test.go`, `test/server.spec.ts`).
- CHANGELOG entry as the last commit so it can be dropped if it belongs elsewhere.

## Verified

- `go vet`, `go test ./... -race`, `make -C agents/android lint`: pass. `TestWebSocket_ConcurrentConnections` times out locally on this branch **and on `main`** with a live emulator attached, so it is pre-existing and environmental.
- Android emulator (Pixel 9 Pro, Android 16, production image, no root): `io pinch 640,1428 --direction out --distance 300` against Chrome on example.com visibly zoomed the page. Raw `sendevent` is blocked by SELinux on that image, which is why the agent route is needed.
- **Not yet tested:** iOS (no simulator booted, no device attached) and a physical Android device.

## Follow-up

The mobile-mcp `mobile_pinch_on_screen` tool comes after a mobilecli release that includes this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pinch-to-zoom gestures through the CLI and device interfaces.
  * Supports inward or outward gestures with optional center coordinates, travel distance, and duration.
  * Added Android support for multi-finger touch gestures using press, move, and release actions.
* **Bug Fixes**
  * Added validation for gesture coordinates, timing, direction, screen boundaries, and maximum duration.
* **Documentation**
  * Updated command help text with pinch gesture usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->