### PR TITLE
feat (android): route tap, longpress, swipe, button, keys and text through the embedded agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [1.0.11](https://github.com/mobile-next/mobilecli/releases/tag/1.0.11) (unreleased)
+* Feat: Tap, long press, swipe, button, keys and text on Android now go through the embedded agent instead of `adb shell input`, which forked a JVM on the device per call, thanks to @akexorcist for finding the bottleneck and the fix in [#286](https://github.com/mobile-next/mobilecli/pull/286) ([#412](https://github.com/mobile-next/mobilecli/pull/412))
 * Fix: `mobilecli io longpress` accepts an element ref like `@e5`, the way `io tap` already did ([#413](https://github.com/mobile-next/mobilecli/pull/413))
 
 ## [1.0.10](https://github.com/mobile-next/mobilecli/releases/tag/1.0.10) (2026-09-11)

--- a/agents/android/java/DeviceServer.java
+++ b/agents/android/java/DeviceServer.java
@@ -8,6 +8,7 @@ import android.view.accessibility.AccessibilityWindowInfo;
 
 import android.util.Base64;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.FileInputStream;
@@ -16,7 +17,7 @@ import java.security.MessageDigest;
 
 /**
  * Persistent device server via app_process. Keeps one connected UiAutomation
- * alive and serves UI dump, screenshot, keyboard, touch gestures, clipboard, app list and mock location
+ * alive and serves UI dump, screenshot, keys, text, touch gestures, clipboard, app list and mock location
  * over JSON-RPC on a localabstract socket, so repeated calls skip process-fork
  * and connect cost, and long-lived state (test location providers) has a home.
  *
@@ -64,6 +65,19 @@ public class DeviceServer {
 				return new JSONObject().put("dismissed", hideKeyboard(automation));
 			case "device.io.gesture":
 				return Gestures.perform(automation, p.optJSONArray("actions"));
+			case "device.io.tap":
+				return Input.tap(automation, requireInt(p, "x"), requireInt(p, "y"));
+			case "device.io.longpress":
+				return Input.longPress(automation, requireInt(p, "x"), requireInt(p, "y"), p.optInt("duration", 500));
+			case "device.io.swipe":
+				return Input.swipe(automation, requireInt(p, "x1"), requireInt(p, "y1"), requireInt(p, "x2"), requireInt(p, "y2"),
+						p.optInt("duration", 1000));
+			case "device.io.button":
+				return Input.pressKey(automation, JsonRpcSocketServer.requireParam(params, "button"), null);
+			case "device.io.keys":
+				return pressKeys(automation, p.optJSONArray("keys"));
+			case "device.io.text":
+				return Input.typeText(automation, JsonRpcSocketServer.requireParam(params, "text"));
 			case "device.clipboard.get":
 				return new JSONObject().put("text", orEmpty(Clipboard.getText()));
 			case "device.clipboard.set":
@@ -95,6 +109,25 @@ public class DeviceServer {
 				p.optInt("quality", 90), p.optDouble("scale", 1.0), p.optInt("maxSize", 0),
 				clip, p.optInt("screenWidth", 0));
 		return new JSONObject().put("data", Base64.encodeToString(image, Base64.NO_WRAP));
+	}
+
+	// keys: [{keycode: "KEYCODE_A", modifiers: ["KEYCODE_CTRL_LEFT"]}, ...], pressed in order
+	private static JSONObject pressKeys(UiAutomation automation, JSONArray keys) throws Exception {
+		if (keys == null || keys.length() == 0) {
+			throw new RpcException(RpcException.INVALID_PARAMS, "missing params.keys");
+		}
+		for (int i = 0; i < keys.length(); i++) {
+			JSONObject key = keys.getJSONObject(i);
+			Input.pressKey(automation, JsonRpcSocketServer.requireParam(key, "keycode"), key.optJSONArray("modifiers"));
+		}
+		return ok();
+	}
+
+	private static int requireInt(JSONObject p, String key) throws RpcException {
+		if (!p.has(key)) {
+			throw new RpcException(RpcException.INVALID_PARAMS, "missing params." + key);
+		}
+		return p.optInt(key);
 	}
 
 	private static JSONObject ok() throws Exception {

--- a/agents/android/java/DeviceServer.java
+++ b/agents/android/java/DeviceServer.java
@@ -68,10 +68,10 @@ public class DeviceServer {
 			case "device.io.tap":
 				return Input.tap(automation, requireInt(p, "x"), requireInt(p, "y"));
 			case "device.io.longpress":
-				return Input.longPress(automation, requireInt(p, "x"), requireInt(p, "y"), p.optInt("duration", 500));
+				return Input.longPress(automation, requireInt(p, "x"), requireInt(p, "y"), optionalInt(p, "duration", 500));
 			case "device.io.swipe":
 				return Input.swipe(automation, requireInt(p, "x1"), requireInt(p, "y1"), requireInt(p, "x2"), requireInt(p, "y2"),
-						p.optInt("duration", 1000));
+						optionalInt(p, "duration", 1000));
 			case "device.io.button":
 				return Input.pressKey(automation, JsonRpcSocketServer.requireParam(params, "button"), null);
 			case "device.io.keys":
@@ -123,11 +123,22 @@ public class DeviceServer {
 		return ok();
 	}
 
+	// optInt turns null, a string or a missing key into 0, which for a coordinate
+	// means silently tapping the top-left corner. Anything that isn't a number is
+	// a bad request instead.
 	private static int requireInt(JSONObject p, String key) throws RpcException {
-		if (!p.has(key)) {
-			throw new RpcException(RpcException.INVALID_PARAMS, "missing params." + key);
+		Object value = p.opt(key);
+		if (!(value instanceof Number)) {
+			throw new RpcException(RpcException.INVALID_PARAMS, "params." + key + " must be a number");
 		}
-		return p.optInt(key);
+		return ((Number) value).intValue();
+	}
+
+	private static int optionalInt(JSONObject p, String key, int fallback) throws RpcException {
+		if (!p.has(key) || p.isNull(key)) {
+			return fallback;
+		}
+		return requireInt(p, key);
 	}
 
 	private static JSONObject ok() throws Exception {

--- a/agents/android/java/DeviceServer.java
+++ b/agents/android/java/DeviceServer.java
@@ -124,14 +124,20 @@ public class DeviceServer {
 	}
 
 	// optInt turns null, a string or a missing key into 0, which for a coordinate
-	// means silently tapping the top-left corner. Anything that isn't a number is
-	// a bad request instead.
+	// means silently tapping the top-left corner, and it truncates or wraps
+	// anything that isn't a plain int. A value that can't be used as given is a
+	// bad request instead.
 	private static int requireInt(JSONObject p, String key) throws RpcException {
 		Object value = p.opt(key);
 		if (!(value instanceof Number)) {
 			throw new RpcException(RpcException.INVALID_PARAMS, "params." + key + " must be a number");
 		}
-		return ((Number) value).intValue();
+		double number = ((Number) value).doubleValue();
+		if (number != Math.rint(number) || number < Integer.MIN_VALUE || number > Integer.MAX_VALUE) {
+			throw new RpcException(RpcException.INVALID_PARAMS,
+					"params." + key + " must be a whole number that fits in an int, got " + value);
+		}
+		return (int) number;
 	}
 
 	private static int optionalInt(JSONObject p, String key, int fallback) throws RpcException {

--- a/agents/android/java/Gestures.java
+++ b/agents/android/java/Gestures.java
@@ -193,15 +193,14 @@ public class Gestures {
 			int action = down.size() == 1
 					? MotionEvent.ACTION_DOWN
 					: MotionEvent.ACTION_POINTER_DOWN | ((down.size() - 1) << MotionEvent.ACTION_POINTER_INDEX_SHIFT);
-			inject(automation, downTime, downTime, action, down, 0);
+			inject(automation, downTime, downTime, action, down, 0, false);
 		}
 
-		for (long atMs = FRAME_MS; !down.isEmpty(); atMs += FRAME_MS) {
-			if (atMs > endMs) atMs = endMs;
+		for (long atMs = Math.min(FRAME_MS, endMs); !down.isEmpty(); atMs = nextFrame(atMs, downTime, endMs)) {
 			sleepUntil(downTime + atMs);
 			long eventTime = SystemClock.uptimeMillis();
 
-			inject(automation, downTime, eventTime, MotionEvent.ACTION_MOVE, down, atMs);
+			inject(automation, downTime, eventTime, MotionEvent.ACTION_MOVE, down, atMs, false);
 
 			for (int i = 0; i < down.size(); ) {
 				Finger finger = down.get(i);
@@ -212,14 +211,18 @@ public class Gestures {
 				int action = down.size() == 1
 						? MotionEvent.ACTION_UP
 						: MotionEvent.ACTION_POINTER_UP | (i << MotionEvent.ACTION_POINTER_INDEX_SHIFT);
-				inject(automation, downTime, eventTime, action, down, atMs);
+				inject(automation, downTime, eventTime, action, down, atMs, down.size() == 1);
 				down.remove(i);
 			}
 		}
 	}
 
+	// Only the event that lifts the last finger is injected synchronously: waiting
+	// for the app to finish handling every intermediate event costs a frame each,
+	// which on a tap is most of the call. Waiting for the final one still means the
+	// gesture has landed by the time the call returns.
 	private static void inject(UiAutomation automation, long downTime, long eventTime, int action,
-			List<Finger> pointers, long atMs) {
+			List<Finger> pointers, long atMs, boolean sync) {
 		int count = pointers.size();
 		MotionEvent.PointerProperties[] properties = new MotionEvent.PointerProperties[count];
 		MotionEvent.PointerCoords[] coords = new MotionEvent.PointerCoords[count];
@@ -241,10 +244,20 @@ public class Gestures {
 		MotionEvent event = MotionEvent.obtain(downTime, eventTime, action, count, properties, coords,
 				0, 0, 1, 1, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0);
 		try {
-			automation.injectInputEvent(event, true);
+			InputInjector.inject(automation, event, sync);
 		} finally {
 			event.recycle();
 		}
+	}
+
+	// A gesture is replayed in real time, so the clock picks the next frame, not
+	// the frame count: injecting is synchronous and can cost more than a frame on
+	// a slow device or emulator, and replaying every frame it fell behind on would
+	// stretch a 1s swipe into several seconds. Skipping them keeps the gesture the
+	// length it was asked for, with fewer intermediate points.
+	private static long nextFrame(long atMs, long downTime, long endMs) {
+		long elapsed = SystemClock.uptimeMillis() - downTime;
+		return Math.min(Math.max(atMs + FRAME_MS, elapsed), endMs);
 	}
 
 	private static void sleepUntil(long uptimeMs) {

--- a/agents/android/java/Gestures.java
+++ b/agents/android/java/Gestures.java
@@ -182,7 +182,7 @@ public class Gestures {
 	// Presses every finger at time zero, then walks the timeline a frame at a
 	// time: one ACTION_MOVE for all fingers still down, then a lift for each
 	// finger whose path has ended, until the last one is up.
-	private static void replay(UiAutomation automation, List<Finger> fingers) {
+	private static void replay(UiAutomation automation, List<Finger> fingers) throws RpcException {
 		long endMs = 0;
 		for (Finger finger : fingers) endMs = Math.max(endMs, finger.liftAtMs());
 
@@ -222,7 +222,7 @@ public class Gestures {
 	// which on a tap is most of the call. Waiting for the final one still means the
 	// gesture has landed by the time the call returns.
 	private static void inject(UiAutomation automation, long downTime, long eventTime, int action,
-			List<Finger> pointers, long atMs, boolean sync) {
+			List<Finger> pointers, long atMs, boolean sync) throws RpcException {
 		int count = pointers.size();
 		MotionEvent.PointerProperties[] properties = new MotionEvent.PointerProperties[count];
 		MotionEvent.PointerCoords[] coords = new MotionEvent.PointerCoords[count];

--- a/agents/android/java/Input.java
+++ b/agents/android/java/Input.java
@@ -1,0 +1,127 @@
+package com.mobilenext.mobilecli;
+
+import android.app.UiAutomation;
+import android.os.SystemClock;
+import android.view.InputDevice;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Single-finger touches and key presses, served by DeviceServer as
+ * device.io.tap / longpress / swipe / button / keys / text. They replace
+ * `adb shell input`, which forks a JVM on the device for every call.
+ *
+ * Touches are expressed as one-finger gestures and replayed by Gestures, so a
+ * tap and a pinch travel the same path. Keys are KEYCODE_* names, resolved on
+ * the device with KeyEvent.keyCodeFromString.
+ */
+public class Input {
+
+	// no hold and no travel: down and up with nothing in between, which is what
+	// `adb shell input tap` sends
+	static JSONObject tap(UiAutomation automation, int x, int y) throws Exception {
+		return Gestures.perform(automation, oneFinger(x, y, 0, x, y, 0));
+	}
+
+	static JSONObject longPress(UiAutomation automation, int x, int y, int durationMs) throws Exception {
+		return Gestures.perform(automation, oneFinger(x, y, durationMs / 1000.0, x, y, 0));
+	}
+
+	static JSONObject swipe(UiAutomation automation, int x1, int y1, int x2, int y2, int durationMs) throws Exception {
+		return Gestures.perform(automation, oneFinger(x1, y1, 0, x2, y2, durationMs / 1000.0));
+	}
+
+	// press at (x1, y1) for holdSeconds, travel to (x2, y2) over moveSeconds, lift
+	private static JSONArray oneFinger(int x1, int y1, double holdSeconds, int x2, int y2, double moveSeconds) throws Exception {
+		JSONArray actions = new JSONArray();
+		actions.put(new JSONObject().put("type", "press").put("x", x1).put("y", y1).put("duration", holdSeconds));
+		if (moveSeconds > 0) {
+			actions.put(new JSONObject().put("type", "move").put("x", x2).put("y", y2).put("duration", moveSeconds));
+		}
+		actions.put(new JSONObject().put("type", "release").put("duration", 0));
+		return actions;
+	}
+
+	/** Presses one key with zero or more modifiers held: modifiers down, key down/up, modifiers up. */
+	static JSONObject pressKey(UiAutomation automation, String keycode, JSONArray modifiers) throws Exception {
+		int code = resolveKeycode(keycode);
+		int count = modifiers == null ? 0 : modifiers.length();
+		int[] modifierCodes = new int[count];
+		for (int i = 0; i < count; i++) {
+			modifierCodes[i] = resolveKeycode(modifiers.getString(i));
+		}
+
+		int meta = 0;
+		for (int modifier : modifierCodes) {
+			meta |= metaFor(modifier);
+			inject(automation, KeyEvent.ACTION_DOWN, modifier, meta);
+		}
+		inject(automation, KeyEvent.ACTION_DOWN, code, meta);
+		inject(automation, KeyEvent.ACTION_UP, code, meta);
+		for (int i = count - 1; i >= 0; i--) {
+			meta &= ~metaFor(modifierCodes[i]);
+			inject(automation, KeyEvent.ACTION_UP, modifierCodes[i], meta);
+		}
+		return ok();
+	}
+
+	/**
+	 * Types text through the virtual keyboard's character map, the way
+	 * `adb shell input text` does. The map only covers what a physical keyboard
+	 * can type, so anything else is INVALID_PARAMS and the host pastes instead.
+	 */
+	static JSONObject typeText(UiAutomation automation, String text) throws Exception {
+		KeyCharacterMap map = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
+		KeyEvent[] events = map.getEvents(text.toCharArray());
+		if (events == null) {
+			throw new RpcException(RpcException.INVALID_PARAMS, "text has characters the keyboard cannot type");
+		}
+		for (KeyEvent event : events) {
+			long now = SystemClock.uptimeMillis();
+			KeyEvent timed = KeyEvent.changeTimeRepeat(event, now, 0);
+			if (timed.getSource() == InputDevice.SOURCE_UNKNOWN) {
+				timed.setSource(InputDevice.SOURCE_KEYBOARD);
+			}
+			InputInjector.inject(automation, timed, false);
+		}
+		return ok();
+	}
+
+	private static void inject(UiAutomation automation, int action, int keycode, int meta) throws RpcException {
+		long now = SystemClock.uptimeMillis();
+		KeyEvent event = new KeyEvent(now, now, action, keycode, 0, meta, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
+				InputDevice.SOURCE_KEYBOARD);
+		InputInjector.inject(automation, event, action == KeyEvent.ACTION_UP);
+	}
+
+	private static int resolveKeycode(String name) throws RpcException {
+		int code = KeyEvent.keyCodeFromString(name);
+		if (code == KeyEvent.KEYCODE_UNKNOWN) {
+			throw new RpcException(RpcException.INVALID_PARAMS, "unknown keycode " + name);
+		}
+		return code;
+	}
+
+	// the meta flags a real keyboard would report while this modifier is down
+	private static int metaFor(int modifier) {
+		switch (modifier) {
+			case KeyEvent.KEYCODE_SHIFT_LEFT: return KeyEvent.META_SHIFT_ON | KeyEvent.META_SHIFT_LEFT_ON;
+			case KeyEvent.KEYCODE_SHIFT_RIGHT: return KeyEvent.META_SHIFT_ON | KeyEvent.META_SHIFT_RIGHT_ON;
+			case KeyEvent.KEYCODE_CTRL_LEFT: return KeyEvent.META_CTRL_ON | KeyEvent.META_CTRL_LEFT_ON;
+			case KeyEvent.KEYCODE_CTRL_RIGHT: return KeyEvent.META_CTRL_ON | KeyEvent.META_CTRL_RIGHT_ON;
+			case KeyEvent.KEYCODE_ALT_LEFT: return KeyEvent.META_ALT_ON | KeyEvent.META_ALT_LEFT_ON;
+			case KeyEvent.KEYCODE_ALT_RIGHT: return KeyEvent.META_ALT_ON | KeyEvent.META_ALT_RIGHT_ON;
+			case KeyEvent.KEYCODE_META_LEFT: return KeyEvent.META_META_ON | KeyEvent.META_META_LEFT_ON;
+			case KeyEvent.KEYCODE_META_RIGHT: return KeyEvent.META_META_ON | KeyEvent.META_META_RIGHT_ON;
+			case KeyEvent.KEYCODE_FUNCTION: return KeyEvent.META_FUNCTION_ON;
+			default: return 0;
+		}
+	}
+
+	private static JSONObject ok() throws Exception {
+		return new JSONObject().put("ok", true);
+	}
+}

--- a/agents/android/java/Input.java
+++ b/agents/android/java/Input.java
@@ -79,13 +79,15 @@ public class Input {
 		if (events == null) {
 			throw new RpcException(RpcException.INVALID_PARAMS, "text has characters the keyboard cannot type");
 		}
-		for (KeyEvent event : events) {
+		for (int i = 0; i < events.length; i++) {
 			long now = SystemClock.uptimeMillis();
-			KeyEvent timed = KeyEvent.changeTimeRepeat(event, now, 0);
+			KeyEvent timed = KeyEvent.changeTimeRepeat(events[i], now, 0);
 			if (timed.getSource() == InputDevice.SOURCE_UNKNOWN) {
 				timed.setSource(InputDevice.SOURCE_KEYBOARD);
 			}
-			InputInjector.inject(automation, timed, false);
+			// wait on the last one, so the text is in the field by the time the
+			// call returns and a dump or screenshot right after sees it
+			InputInjector.inject(automation, timed, i == events.length - 1);
 		}
 		return ok();
 	}

--- a/agents/android/java/InputInjector.java
+++ b/agents/android/java/InputInjector.java
@@ -1,0 +1,62 @@
+package com.mobilenext.mobilecli;
+
+import android.app.UiAutomation;
+import android.view.InputEvent;
+
+import java.lang.reflect.Method;
+
+/**
+ * Injects input events straight into InputManager, the way the `input` command
+ * does. UiAutomation.injectInputEvent ends up in the same place but goes
+ * through the accessibility connection first, and that extra hop costs tens of
+ * milliseconds per event — most of the time a tap or a line of text takes.
+ *
+ * The singleton moved to InputManagerGlobal in Android 14 and neither class is
+ * public API, so it's resolved by reflection once, with UiAutomation as the
+ * fallback for platforms that don't expose it.
+ */
+class InputInjector {
+
+	// InputManager.INJECT_INPUT_EVENT_MODE_*
+	private static final int ASYNC = 0;
+	private static final int WAIT_FOR_FINISH = 2;
+
+	private static final Object INPUT_MANAGER = resolveInputManager();
+	private static final Method INJECT = resolveInject(INPUT_MANAGER);
+
+	/** Injects one event; sync waits for the app to finish handling it. */
+	static void inject(UiAutomation automation, InputEvent event, boolean sync) {
+		if (INJECT == null) {
+			automation.injectInputEvent(event, sync);
+			return;
+		}
+		try {
+			INJECT.invoke(INPUT_MANAGER, event, sync ? WAIT_FOR_FINISH : ASYNC);
+		} catch (Exception e) {
+			automation.injectInputEvent(event, sync);
+		}
+	}
+
+	private static Object resolveInputManager() {
+		try {
+			return Class.forName("android.hardware.input.InputManagerGlobal").getMethod("getInstance").invoke(null);
+		} catch (Exception e) {
+			try {
+				return Class.forName("android.hardware.input.InputManager").getMethod("getInstance").invoke(null);
+			} catch (Exception e2) {
+				return null;
+			}
+		}
+	}
+
+	private static Method resolveInject(Object inputManager) {
+		if (inputManager == null) {
+			return null;
+		}
+		try {
+			return inputManager.getClass().getMethod("injectInputEvent", InputEvent.class, int.class);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+}

--- a/agents/android/java/InputInjector.java
+++ b/agents/android/java/InputInjector.java
@@ -24,16 +24,27 @@ class InputInjector {
 	private static final Object INPUT_MANAGER = resolveInputManager();
 	private static final Method INJECT = resolveInject(INPUT_MANAGER);
 
-	/** Injects one event; sync waits for the app to finish handling it. */
-	static void inject(UiAutomation automation, InputEvent event, boolean sync) {
-		if (INJECT == null) {
-			automation.injectInputEvent(event, sync);
-			return;
+	/**
+	 * Injects one event; sync waits for the app to finish handling it. The
+	 * platform refusing an event is an error, not a quiet no-op: a caller told
+	 * its tap landed when nothing happened has no way to tell.
+	 */
+	static void inject(UiAutomation automation, InputEvent event, boolean sync) throws RpcException {
+		int mode = sync ? WAIT_FOR_FINISH : ASYNC;
+		if (INJECT != null) {
+			try {
+				if (!(Boolean) INJECT.invoke(INPUT_MANAGER, event, mode)) {
+					throw new RpcException(RpcException.INTERNAL_ERROR, "device refused " + event);
+				}
+				return;
+			} catch (RpcException e) {
+				throw e;
+			} catch (Exception e) {
+				// the hidden method went away under us; the public path still works
+			}
 		}
-		try {
-			INJECT.invoke(INPUT_MANAGER, event, sync ? WAIT_FOR_FINISH : ASYNC);
-		} catch (Exception e) {
-			automation.injectInputEvent(event, sync);
+		if (!automation.injectInputEvent(event, sync)) {
+			throw new RpcException(RpcException.INTERNAL_ERROR, "device refused " + event);
 		}
 	}
 

--- a/devices/android.go
+++ b/devices/android.go
@@ -52,6 +52,44 @@ type gestureParams struct {
 	Actions []devicekit.GestureAction `json:"actions"`
 }
 
+type tapParams struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+type longPressParams struct {
+	X        int `json:"x"`
+	Y        int `json:"y"`
+	Duration int `json:"duration"`
+}
+
+type swipeParams struct {
+	X1       int `json:"x1"`
+	Y1       int `json:"y1"`
+	X2       int `json:"x2"`
+	Y2       int `json:"y2"`
+	Duration int `json:"duration"`
+}
+
+type buttonParams struct {
+	Button string `json:"button"`
+}
+
+// keyParams is one entry of device.io.keys: a KEYCODE_* name with the
+// KEYCODE_* names of the modifiers held while it's pressed.
+type keyParams struct {
+	Keycode   string   `json:"keycode"`
+	Modifiers []string `json:"modifiers,omitempty"`
+}
+
+type keysParams struct {
+	Keys []keyParams `json:"keys"`
+}
+
+type textParams struct {
+	Text string `json:"text"`
+}
+
 type AndroidDevice struct {
 	id          string
 	name        string
@@ -477,24 +515,18 @@ func (d *AndroidDevice) Shutdown() error {
 	return nil
 }
 
-// Tap simulates a tap at (x, y) on the Android device.
+// Tap, LongPress and Swipe go through the on-device server (Input.java),
+// which injects them via UiAutomation. `adb shell input` forks a JVM on the
+// device for every call, which is where most of its ~200ms went.
 func (d *AndroidDevice) Tap(x, y int) error {
-	_, err := d.runAdbCommand("shell", "input", "tap", fmt.Sprintf("%d", x), fmt.Sprintf("%d", y))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := d.serverRequest("device.io.tap", tapParams{X: x, Y: y})
+	return err
 }
 
 // LongPress simulates a long press at (x, y) on the Android device.
 func (d *AndroidDevice) LongPress(x, y, duration int) error {
-	_, err := d.runAdbCommand("shell", "input", "swipe", fmt.Sprintf("%d", x), fmt.Sprintf("%d", y), fmt.Sprintf("%d", x), fmt.Sprintf("%d", y), fmt.Sprintf("%d", duration))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := d.serverRequest("device.io.longpress", longPressParams{X: x, Y: y, Duration: duration})
+	return err
 }
 
 const defaultSwipeDurationMs = 1000
@@ -506,12 +538,8 @@ func (d *AndroidDevice) Swipe(x1, y1, x2, y2, duration int) error {
 		duration = defaultSwipeDurationMs
 	}
 
-	_, err := d.runAdbCommand("shell", "input", "swipe", fmt.Sprintf("%d", x1), fmt.Sprintf("%d", y1), fmt.Sprintf("%d", x2), fmt.Sprintf("%d", y2), fmt.Sprintf("%d", duration))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := d.serverRequest("device.io.swipe", swipeParams{X1: x1, Y1: y1, X2: x2, Y2: y2, Duration: duration})
+	return err
 }
 
 func (d *AndroidDevice) GetClipboard() (string, error) {
@@ -808,11 +836,9 @@ func (d *AndroidDevice) PressButton(key string) error {
 		return fmt.Errorf("AndroidDevice: unsupported button key: %s", key)
 	}
 
-	output, err := d.runAdbCommand("shell", "input", "keyevent", keycode)
-	if err != nil {
-		return fmt.Errorf("AndroidDevice: failed to press %s button: %v\nOutput: %s", key, err, string(output))
+	if _, err := d.serverRequest("device.io.button", buttonParams{Button: keycode}); err != nil {
+		return fmt.Errorf("AndroidDevice: failed to press %s button: %w", key, err)
 	}
-
 	return nil
 }
 
@@ -876,41 +902,28 @@ func androidKeycodeForKey(key string) (string, error) {
 }
 
 func (d *AndroidDevice) PressKeys(combos []KeyCombo) error {
-	// resolve all combos into adb args upfront, so an invalid combo fails
-	// before any key is pressed
-	adbArgs := make([][]string, len(combos))
+	// resolve every combo upfront, so an invalid one fails before any key is pressed
+	keys := make([]keyParams, len(combos))
 	for i, combo := range combos {
 		keycode, err := androidKeycodeForKey(combo.Key)
 		if err != nil {
 			return err
 		}
 
-		if len(combo.Modifiers) == 0 {
-			adbArgs[i] = []string{"shell", "input", "keyevent", keycode}
-			continue
-		}
-
-		args := []string{"shell", "input", "keycombination"}
+		var modifiers []string
 		for _, modifier := range combo.Modifiers {
 			modifierKeycode, ok := androidModifierKeycodes[modifier]
 			if !ok {
 				return fmt.Errorf("AndroidDevice: unsupported modifier: %s", modifier)
 			}
-			args = append(args, modifierKeycode)
+			modifiers = append(modifiers, modifierKeycode)
 		}
-		adbArgs[i] = append(args, keycode)
+		keys[i] = keyParams{Keycode: keycode, Modifiers: modifiers}
 	}
 
-	for i, args := range adbArgs {
-		output, err := d.runAdbCommand(args...)
-		if err != nil {
-			if strings.Contains(string(output), "Unknown command") {
-				return fmt.Errorf("AndroidDevice: key combinations require Android 12 or newer")
-			}
-			return fmt.Errorf("AndroidDevice: failed to press key '%s': %v\nOutput: %s", combos[i].Key, err, string(output))
-		}
+	if _, err := d.serverRequest("device.io.keys", keysParams{Keys: keys}); err != nil {
+		return fmt.Errorf("AndroidDevice: failed to press keys: %w", err)
 	}
-
 	return nil
 }
 
@@ -922,21 +935,6 @@ func isAscii(text string) bool {
 		}
 	}
 	return true
-}
-
-// escapeShellText escapes shell special characters
-func escapeShellText(text string) string {
-	// escape all shell special characters that could be used for injection
-	specialChars := `\'"` + "`" + `
-|&;()<>{}[]$*? `
-	result := ""
-	for _, char := range text {
-		if strings.ContainsRune(specialChars, char) {
-			result += "\\"
-		}
-		result += string(char)
-	}
-	return result
 }
 
 func (d *AndroidDevice) SendKeys(text string) error {
@@ -954,14 +952,13 @@ func (d *AndroidDevice) SendKeys(text string) error {
 	}
 
 	if isAscii(text) {
-		// adb shell input only supports ascii characters. and
-		// some of the keys have to be escaped.
-		escapedText := escapeShellText(text)
-		_, err := d.runAdbCommand("shell", "input", "text", escapedText)
+		// the virtual keyboard's character map only covers what a physical
+		// keyboard can type, which is ascii
+		_, err := d.serverRequest("device.io.text", textParams{Text: text})
 		return err
 	}
 
-	// adb shell input can't carry non-ASCII; put it on the clipboard and paste
+	// anything else can't be typed key by key; put it on the clipboard and paste
 	if err := d.SetClipboard(text); err != nil {
 		return fmt.Errorf("failed to set clipboard: %w", err)
 	}
@@ -971,7 +968,7 @@ func (d *AndroidDevice) SendKeys(text string) error {
 		}
 	}()
 
-	if _, err := d.runAdbCommand("shell", "input", "keyevent", "KEYCODE_PASTE"); err != nil {
+	if _, err := d.serverRequest("device.io.button", buttonParams{Button: "KEYCODE_PASTE"}); err != nil {
 		return fmt.Errorf("failed to paste: %w", err)
 	}
 	return nil

--- a/devices/android.go
+++ b/devices/android.go
@@ -97,6 +97,10 @@ type AndroidDevice struct {
 	state       string // "online" or "offline"
 	transportID string // adb transport ID (e.g., "emulator-5554"), only set for online devices
 	model       string
+
+	// host port of the DeviceServer once it's known to be up and current
+	serverMu   sync.Mutex
+	serverPort int
 }
 
 func (d *AndroidDevice) ID() string {

--- a/devices/android.go
+++ b/devices/android.go
@@ -906,6 +906,10 @@ func androidKeycodeForKey(key string) (string, error) {
 }
 
 func (d *AndroidDevice) PressKeys(combos []KeyCombo) error {
+	if len(combos) == 0 {
+		return nil
+	}
+
 	// resolve every combo upfront, so an invalid one fails before any key is pressed
 	keys := make([]keyParams, len(combos))
 	for i, combo := range combos {

--- a/devices/android_device_server.go
+++ b/devices/android_device_server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -30,11 +31,42 @@ const deviceServerTarget = "localabstract:mobilecli-server"
 // dumpUiWaitUntilIdleMs is how long a dump waits for the UI to settle.
 const dumpUiWaitUntilIdleMs = 2000
 
-// ensureDeviceServerReady makes sure the persistent DeviceServer is running,
-// forwarded, and built from this binary's dex, reusing an existing forward when
-// possible. It's launched detached (nohup + &) on the device shell so it
-// outlives this CLI invocation and keeps serving subsequent mobilecli calls.
+// ensureDeviceServerReady returns the port of a DeviceServer that is running,
+// forwarded and built from this binary's dex, starting it if needed.
+//
+// The port is remembered for the lifetime of the device: checking it costs an
+// `adb forward --list` process plus two round trips, which is more than most
+// calls it guards. serverRequest drops it and comes back here if the server
+// turns out to be gone.
 func (d *AndroidDevice) ensureDeviceServerReady() (int, error) {
+	d.serverMu.Lock()
+	defer d.serverMu.Unlock()
+
+	if d.serverPort != 0 {
+		return d.serverPort, nil
+	}
+
+	port, err := d.startDeviceServer()
+	if err != nil {
+		return 0, err
+	}
+	d.serverPort = port
+	return port, nil
+}
+
+// forgetDeviceServer drops the remembered port, so the next call checks the
+// server again and restarts it if it is really gone.
+func (d *AndroidDevice) forgetDeviceServer() {
+	d.serverMu.Lock()
+	defer d.serverMu.Unlock()
+	d.serverPort = 0
+}
+
+// startDeviceServer finds or launches the DeviceServer and returns its host
+// port, reusing an existing forward when possible. It's launched detached
+// (nohup + &) on the device shell so it outlives this CLI invocation and keeps
+// serving subsequent mobilecli calls.
+func (d *AndroidDevice) startDeviceServer() (int, error) {
 	if port := d.findForward(deviceServerTarget); port != 0 && isAgentReady(port) {
 		if d.deviceServerMatchesEmbeddedDex(port) {
 			return port, nil
@@ -126,11 +158,25 @@ func embeddedDexSHA256() string {
 }
 
 // serverRequest sends a JSON-RPC call to the persistent DeviceServer, starting
-// it if needed.
+// it if needed. A server that has gone away (device rebooted, another mobilecli
+// build restarted it) is set up again once and the call retried, so the
+// remembered port never strands a session.
 func (d *AndroidDevice) serverRequest(method string, params any) (json.RawMessage, error) {
 	port, err := d.ensureDeviceServerReady()
 	if err != nil {
 		return nil, err
+	}
+
+	raw, err := agentRequest(port, method, params)
+	if !errors.Is(err, errAgentUnreachable) {
+		return raw, err
+	}
+
+	utils.Verbose("device server on port %d is gone, starting it again", port)
+	d.forgetDeviceServer()
+	port, startErr := d.ensureDeviceServerReady()
+	if startErr != nil {
+		return nil, fmt.Errorf("%w (restart failed: %v)", err, startErr)
 	}
 	return agentRequest(port, method, params)
 }

--- a/devices/android_device_server.go
+++ b/devices/android_device_server.go
@@ -160,7 +160,9 @@ func embeddedDexSHA256() string {
 // serverRequest sends a JSON-RPC call to the persistent DeviceServer, starting
 // it if needed. A server that has gone away (device rebooted, another mobilecli
 // build restarted it) is set up again once and the call retried, so the
-// remembered port never strands a session.
+// remembered port never strands a session. A call that timed out is never
+// resent: the server may still be running it, and repeating a tap or a line of
+// text is worse than reporting the timeout.
 func (d *AndroidDevice) serverRequest(method string, params any) (json.RawMessage, error) {
 	port, err := d.ensureDeviceServerReady()
 	if err != nil {

--- a/devices/android_rpc.go
+++ b/devices/android_rpc.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -23,6 +24,11 @@ const defaultAgentTimeout = 10 * time.Second
 // an error the agent itself reported. Callers that can restart their agent use
 // it to tell "it died" from "it said no".
 var errAgentUnreachable = errors.New("agent unreachable")
+
+// errAgentTimedOut is the one unreachable case that must not be repeated: the
+// agent may well be working on the request, so sending it again would run it
+// twice.
+var errAgentTimedOut = errors.New("agent timed out")
 
 // jsonRPCRequest is the envelope every agent call is wrapped in. Params is
 // whatever shape the method takes, typically a small struct declared next to
@@ -54,6 +60,9 @@ func agentRequestWithTimeout(port int, method string, params any, timeout time.D
 	client := &http.Client{Timeout: timeout}
 	resp, err := postJSON(client, port, bytes.NewReader(payload))
 	if err != nil {
+		if netErr := net.Error(nil); errors.As(err, &netErr) && netErr.Timeout() {
+			return nil, fmt.Errorf("%w on port %d after %s: %v", errAgentTimedOut, port, timeout, err)
+		}
 		return nil, fmt.Errorf("%w on port %d: %v", errAgentUnreachable, port, err)
 	}
 	defer resp.Body.Close()

--- a/devices/android_rpc.go
+++ b/devices/android_rpc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +18,11 @@ import (
 // socket and the in-app webview agent.
 
 const defaultAgentTimeout = 10 * time.Second
+
+// errAgentUnreachable marks a failure to reach an agent at all, as opposed to
+// an error the agent itself reported. Callers that can restart their agent use
+// it to tell "it died" from "it said no".
+var errAgentUnreachable = errors.New("agent unreachable")
 
 // jsonRPCRequest is the envelope every agent call is wrapped in. Params is
 // whatever shape the method takes, typically a small struct declared next to
@@ -48,7 +54,7 @@ func agentRequestWithTimeout(port int, method string, params any, timeout time.D
 	client := &http.Client{Timeout: timeout}
 	resp, err := postJSON(client, port, bytes.NewReader(payload))
 	if err != nil {
-		return nil, fmt.Errorf("connect to agent on port %d: %w", port, err)
+		return nil, fmt.Errorf("%w on port %d: %v", errAgentUnreachable, port, err)
 	}
 	defer resp.Body.Close()
 

--- a/devices/android_rpc_test.go
+++ b/devices/android_rpc_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/mobile-next/mobilecli/devices/devicekit"
 	"github.com/mobile-next/mobilecli/types"
@@ -116,4 +117,24 @@ func TestAgentRequestReportsAnErrorTheAgentItselfSentAsSomethingElse(t *testing.
 
 	assert.Error(t, err)
 	assert.NotErrorIs(t, err, errAgentUnreachable)
+}
+
+func TestAgentRequestReportsATimeoutSeparatelyFromAnUnreachableAgent(t *testing.T) {
+	slowAgent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer slowAgent.Close()
+	port := slowAgent.Listener.Addr().(*net.TCPAddr).Port
+
+	_, err := agentRequestWithTimeout(port, "device.dump.ui", nil, 10*time.Millisecond)
+
+	assert.ErrorIs(t, err, errAgentTimedOut)
+	assert.NotErrorIs(t, err, errAgentUnreachable, "a timed-out call must not be resent")
+}
+
+func TestPressingNoKeysDoesNothingRatherThanAskingTheServerToPressNothing(t *testing.T) {
+	device := &AndroidDevice{id: "no-such-device"}
+
+	assert.NoError(t, device.PressKeys(nil))
+	assert.NoError(t, device.PressKeys([]KeyCombo{}))
 }

--- a/devices/android_rpc_test.go
+++ b/devices/android_rpc_test.go
@@ -2,6 +2,9 @@ package devices
 
 import (
 	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/mobile-next/mobilecli/devices/devicekit"
@@ -84,4 +87,33 @@ func TestInputParamsUseTheOpenRpcFieldNames(t *testing.T) {
 	assert.ElementsMatch(t, []string{"x1", "y1", "x2", "y2", "duration"}, wireKeys(t, swipeParams{X1: 1, Y1: 2, X2: 3, Y2: 4, Duration: 300}))
 	assert.ElementsMatch(t, []string{"button"}, wireKeys(t, buttonParams{Button: "KEYCODE_HOME"}))
 	assert.ElementsMatch(t, []string{"text"}, wireKeys(t, textParams{Text: "hi"}))
+}
+
+// freePort returns a port with nothing listening on it.
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+	return port
+}
+
+func TestAgentRequestReportsAnAgentItCannotReachAsUnreachable(t *testing.T) {
+	_, err := agentRequest(freePort(t), "device.version", nil)
+
+	assert.ErrorIs(t, err, errAgentUnreachable)
+}
+
+func TestAgentRequestReportsAnErrorTheAgentItselfSentAsSomethingElse(t *testing.T) {
+	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32601,"message":"Method not found"}}`))
+	}))
+	defer agent.Close()
+	port := agent.Listener.Addr().(*net.TCPAddr).Port
+
+	_, err := agentRequest(port, "device.nonsense", nil)
+
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, errAgentUnreachable)
 }

--- a/devices/android_rpc_test.go
+++ b/devices/android_rpc_test.go
@@ -68,3 +68,20 @@ func TestScreenshotParamsUseTheKeysDeviceServerReads(t *testing.T) {
 	assert.ElementsMatch(t, []string{"format", "quality", "scale", "maxSize", "clip", "screenWidth"}, wireKeys(t, clipped))
 	assert.ElementsMatch(t, []string{"x", "y", "width", "height"}, wireKeys(t, clipped.Clip))
 }
+
+func TestKeysParamsCarryKeycodeAndModifiersPerKey(t *testing.T) {
+	payload, err := json.Marshal(keysParams{Keys: []keyParams{
+		{Keycode: "KEYCODE_A", Modifiers: []string{"KEYCODE_CTRL_LEFT"}},
+		{Keycode: "KEYCODE_ENTER"},
+	}})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"keys":[{"keycode":"KEYCODE_A","modifiers":["KEYCODE_CTRL_LEFT"]},{"keycode":"KEYCODE_ENTER"}]}`, string(payload))
+}
+
+func TestInputParamsUseTheOpenRpcFieldNames(t *testing.T) {
+	assert.ElementsMatch(t, []string{"x", "y"}, wireKeys(t, tapParams{X: 1, Y: 2}))
+	assert.ElementsMatch(t, []string{"x", "y", "duration"}, wireKeys(t, longPressParams{X: 1, Y: 2, Duration: 500}))
+	assert.ElementsMatch(t, []string{"x1", "y1", "x2", "y2", "duration"}, wireKeys(t, swipeParams{X1: 1, Y1: 2, X2: 3, Y2: 4, Duration: 300}))
+	assert.ElementsMatch(t, []string{"button"}, wireKeys(t, buttonParams{Button: "KEYCODE_HOME"}))
+	assert.ElementsMatch(t, []string{"text"}, wireKeys(t, textParams{Text: "hi"}))
+}


### PR DESCRIPTION
Every Android input operation went out as `adb shell input`, which forks a JVM on the device for each call. They now go to the DeviceServer that is already running for `dump ui` and screenshots.

Credit for this goes to @akexorcist, who identified the bottleneck and demonstrated the fix in #286 while writing end-to-end tests against a real app: keep a connection to the device open and inject input directly instead of paying a process spawn per command. The measurements there, 226ms → 5.6ms for a tap on real hardware, are what prompted this work.

What this PR does differently is only where the code lives. It puts the same idea inside the DeviceServer we already run for `dump ui` and screenshots, rather than adding a second dex and socket protocol alongside it, and it uses the method and parameter names already in `docs/openrpc.json`. The `InputManager` insight, that going around `UiAutomation` is what makes injection fast, is his.

## What changed

New server methods (`Input.java`, dispatched by `DeviceServer`): `device.io.tap`, `device.io.longpress`, `device.io.swipe`, `device.io.button`, `device.io.keys`, `device.io.text`.

- Touches are expressed as a one-finger gesture and replayed by `Gestures`, so a tap and a pinch take the same path.
- Keys are injected with their modifiers held down, which drops the `input keycombination` dependency and its Android 12 floor.
- Text goes through the virtual keyboard's character map, the same mechanism `input text` uses. Non-ASCII still pastes from the clipboard, and the shell escaping the old path needed is gone.

Three things cost far more than the work itself and are fixed here:

- **Every call rechecked the device server**: an `adb forward --list` process, a readiness ping and a dex-hash round trip, to guard a call that costs less than all three. The port is now remembered for the lifetime of the device. A server that has gone away is noticed, restarted and the call retried once, except after a timeout, where the server may still be running the request and repeating a tap would be worse than reporting it.
- **`UiAutomation.injectInputEvent` goes through the accessibility connection**, tens of milliseconds per event. `InputInjector` calls `InputManager` directly, the way the `input` command does, with `UiAutomation` as the fallback.
- **`Gestures` replayed a fixed 16ms per frame.** When injection cost more than a frame the gesture ran long, and a 1s swipe took 6s. The clock now picks the next frame and skipped ones are dropped, so a gesture takes the time it was asked for. This fixes `io pinch` too.

## Numbers

Pixel 9 Pro emulator, `mobilecli server` and its daemon both from the build under test, 30 runs each, median. Taps land on a dead region of the screen so the figure is transport and injection, not how fast an app reacts.

| op | before | after |
| --- | --- | --- |
| tap | 20.2ms | 4.0ms |
| keys | 18.0ms | 2.8ms |
| text ("hello") | 19.9ms | 4.9ms |
| button | 202.7ms | 6.1ms |

Repeated twice with the same result. `button` is the widest gap because `adb shell input keyevent` waits for the volume UI to react.

An emulator is the friendliest case for the old path, since `adb shell` never leaves the host. A physical device pays a USB round trip per call, which is why @akexorcist measured a far wider gap in #286.

`longpress` and `swipe` are unchanged, because both are dominated by the duration the caller asked for rather than by overhead.

## Test plan

Verified on a Pixel 9 Pro emulator that each operation produces the real on-screen result, not just a success code:

- [x] swipe up on the home screen opens the app drawer
- [x] text types into the Settings search field
- [x] `ctrl+a` then `backspace` clears that field
- [x] non-ASCII text ("héllo 🙂") still lands, via the clipboard fallback
- [x] long press on the home screen opens the wallpaper menu
- [x] tap by element ref, `io button HOME`, and `io pinch` all still work
- [x] killing the on-device server mid-session: the next call recovers in 405ms and succeeds
- [x] a non-numeric coordinate or duration is refused by the server rather than tapping (0,0)
- [x] `go build ./...`, `go test ./...`, `gofmt`, `make -C agents/android lint`

Not covered: a physical device, and Android versions older than the emulator's API 35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Android support for tap, long-press, swipe, button presses, key combinations, text entry, and clipboard paste.
  - Added keyboard support, including modifier keys and named key sequences.
  - Added validation with clear errors for invalid parameters, unsupported text, and unknown keys.

- **Bug Fixes**
  - Improved gesture timing so delayed frames are skipped rather than extending gesture duration.
  - Improved Android input reliability and automatic recovery when the device server becomes unreachable.
  - Requests that time out are now reported distinctly and are not retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
