### PR TITLE
fix: accept an element ref in `io longpress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.11](https://github.com/mobile-next/mobilecli/releases/tag/1.0.11) (unreleased)
+* Fix: `mobilecli io longpress` accepts an element ref like `@e5`, the way `io tap` already did ([#413](https://github.com/mobile-next/mobilecli/pull/413))
+
 ## [1.0.10](https://github.com/mobile-next/mobilecli/releases/tag/1.0.10) (2026-09-11)
 * Feat: Pinch to zoom with `mobilecli io pinch` and `device.io.pinch`, and a real multi-finger `device.io.gesture` on Android through the embedded agent ([#410](https://github.com/mobile-next/mobilecli/pull/410))
 * Fix: Don't hang on a locked keyring when reading credentials; time out after 3s and continue without remote devices ([#408](https://github.com/mobile-next/mobilecli/pull/408)), thanks to [@EnglandLobster](https://github.com/EnglandLobster)

--- a/cli/io.go
+++ b/cli/io.go
@@ -15,40 +15,53 @@ var ioCmd = &cobra.Command{
 	Long:  `Perform input/output operations like tapping, pressing buttons, sending text, and reading or writing the device clipboard.`,
 }
 
+// screenPoint is where a touch command should land: either explicit
+// coordinates or an element ref ("@e5") to resolve against the current screen.
+type screenPoint struct {
+	X   int
+	Y   int
+	Ref string
+}
+
+// parseScreenPoint reads the single argument tap and longpress take: "x,y" or
+// an element ref from the latest "dump ui".
+func parseScreenPoint(arg string) (screenPoint, error) {
+	if strings.HasPrefix(arg, "@") {
+		return screenPoint{Ref: arg}, nil
+	}
+
+	parts := strings.Split(arg, ",")
+	if len(parts) != 2 {
+		return screenPoint{}, fmt.Errorf("invalid target format. Expected 'x,y' coordinates or an element ref like '@e15', got '%s'", arg)
+	}
+
+	x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
+	y, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if errX != nil || errY != nil {
+		return screenPoint{}, fmt.Errorf("invalid coordinate values. x and y must be integers. Got x='%s', y='%s'", parts[0], parts[1])
+	}
+
+	return screenPoint{X: x, Y: y}, nil
+}
+
 var ioTapCmd = &cobra.Command{
 	Use:   "tap [x,y | @ref]",
 	Short: "Tap on a device screen at the given coordinates or element ref",
 	Long:  `Sends a tap event to the specified device at the given x,y coordinates ("x,y"), or at the center of an element ref from the latest "dump ui" (e.g. "@e5").`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		coordsStr := args[0]
-		if strings.HasPrefix(coordsStr, "@") {
-			return runViaDaemon("cli.io.tap", commands.TapRequest{
-				DeviceID: deviceId,
-				Ref:      coordsStr,
-			})
-		}
-
-		parts := strings.Split(coordsStr, ",")
-		if len(parts) != 2 {
-			response := commands.NewErrorResponse(fmt.Errorf("invalid target format. Expected 'x,y' coordinates or an element ref like '@e15', got '%s'", coordsStr))
-			printJson(response)
-			return fmt.Errorf("%s", response.Error)
-		}
-
-		x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
-		y, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
-
-		if errX != nil || errY != nil {
-			response := commands.NewErrorResponse(fmt.Errorf("invalid coordinate values. x and y must be integers. Got x='%s', y='%s'", parts[0], parts[1]))
+		target, err := parseScreenPoint(args[0])
+		if err != nil {
+			response := commands.NewErrorResponse(err)
 			printJson(response)
 			return fmt.Errorf("%s", response.Error)
 		}
 
 		req := commands.TapRequest{
 			DeviceID: deviceId,
-			X:        x,
-			Y:        y,
+			X:        target.X,
+			Y:        target.Y,
+			Ref:      target.Ref,
 		}
 
 		return runViaDaemon("cli.io.tap", req)
@@ -62,33 +75,24 @@ var pinchDistance int
 var pinchDuration int
 
 var ioLongPressCmd = &cobra.Command{
-	Use:   "longpress [x,y]",
-	Short: "Long press on a device screen at the given coordinates",
-	Long:  `Sends a long press event to the specified device at the given x,y coordinates. Coordinates should be provided as a single string "x,y".`,
+	Use:   "longpress [x,y | @ref]",
+	Short: "Long press on a device screen at the given coordinates or element ref",
+	Long:  `Sends a long press event to the specified device at the given x,y coordinates ("x,y"), or at the center of an element ref from the latest "dump ui" (e.g. "@e5").`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		coordsStr := args[0]
-		parts := strings.Split(coordsStr, ",")
-		if len(parts) != 2 {
-			response := commands.NewErrorResponse(fmt.Errorf("invalid coordinate format. Expected 'x,y', got '%s'", coordsStr))
-			printJson(response)
-			return fmt.Errorf("%s", response.Error)
-		}
-
-		x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
-		y, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
-
-		if errX != nil || errY != nil {
-			response := commands.NewErrorResponse(fmt.Errorf("invalid coordinate values. x and y must be integers. Got x='%s', y='%s'", parts[0], parts[1]))
+		target, err := parseScreenPoint(args[0])
+		if err != nil {
+			response := commands.NewErrorResponse(err)
 			printJson(response)
 			return fmt.Errorf("%s", response.Error)
 		}
 
 		req := commands.LongPressRequest{
 			DeviceID: deviceId,
-			X:        x,
-			Y:        y,
+			X:        target.X,
+			Y:        target.Y,
 			Duration: longPressDuration,
+			Ref:      target.Ref,
 		}
 
 		return runViaDaemon("cli.io.longpress", req)

--- a/cli/io_test.go
+++ b/cli/io_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoordinatesAreParsedAsAPoint(t *testing.T) {
+	target, err := parseScreenPoint("150,300")
+
+	require.NoError(t, err)
+	assert.Equal(t, screenPoint{X: 150, Y: 300}, target)
+}
+
+func TestSpacesAroundCoordinatesAreIgnored(t *testing.T) {
+	target, err := parseScreenPoint(" 150 , 300 ")
+
+	require.NoError(t, err)
+	assert.Equal(t, screenPoint{X: 150, Y: 300}, target)
+}
+
+func TestAnElementRefIsPassedThroughForTheDeviceToResolve(t *testing.T) {
+	target, err := parseScreenPoint("@e45")
+
+	require.NoError(t, err)
+	assert.Equal(t, screenPoint{Ref: "@e45"}, target)
+}
+
+func TestSomethingThatIsNeitherCoordinatesNorARefIsRejected(t *testing.T) {
+	for _, arg := range []string{"150", "150,300,450", "left,300", ""} {
+		_, err := parseScreenPoint(arg)
+
+		assert.Error(t, err, "expected %q to be rejected", arg)
+	}
+}

--- a/commands/input.go
+++ b/commands/input.go
@@ -18,12 +18,14 @@ type TapRequest struct {
 	Ref      string `json:"ref,omitempty"`
 }
 
-// LongPressRequest represents the parameters for a long press command
+// LongPressRequest represents the parameters for a long press command. Either
+// X,Y or Ref ("@e5", from the latest dump) must be set; Ref wins when both are.
 type LongPressRequest struct {
 	DeviceID string `json:"deviceId"`
 	X        int    `json:"x"`
 	Y        int    `json:"y"`
 	Duration int    `json:"duration"`
+	Ref      string `json:"ref,omitempty"`
 }
 
 // TextRequest represents the parameters for a text input command
@@ -199,7 +201,7 @@ func findElementByRef(elements []types.ScreenElement, ref string) *types.ScreenE
 
 // LongPressCommand performs a long press operation on the specified device
 func LongPressCommand(req LongPressRequest) *CommandResponse {
-	if req.X < 0 || req.Y < 0 {
+	if req.Ref == "" && (req.X < 0 || req.Y < 0) {
 		return NewErrorResponse(fmt.Errorf("x and y coordinates must be non-negative, got x=%d, y=%d", req.X, req.Y))
 	}
 
@@ -215,13 +217,21 @@ func LongPressCommand(req LongPressRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
 	}
 
-	err = targetDevice.LongPress(req.X, req.Y, req.Duration)
+	x, y := req.X, req.Y
+	if req.Ref != "" {
+		x, y, err = resolveRefTapPoint(targetDevice, req.Ref)
+		if err != nil {
+			return NewErrorResponse(err)
+		}
+	}
+
+	err = targetDevice.LongPress(x, y, req.Duration)
 	if err != nil {
 		return NewErrorResponse(fmt.Errorf("failed to long press on device %s: %v", targetDevice.ID(), err))
 	}
 
 	return NewSuccessResponse(MessageResult{
-		Message: fmt.Sprintf("Long pressed on device %s at (%d,%d) for %dms", targetDevice.ID(), req.X, req.Y, req.Duration),
+		Message: fmt.Sprintf("Long pressed on device %s at (%d,%d) for %dms", targetDevice.ID(), x, y, req.Duration),
 	})
 }
 

--- a/skills/mobilecli/SKILL.md
+++ b/skills/mobilecli/SKILL.md
@@ -128,7 +128,7 @@ Here is a quick reference table mapping standard user actions to `mobilecli` com
 | User Action | CLI Command | Description |
 | :--- | :--- | :--- |
 | **Tap** | `mobilecli io tap @e5` or `mobilecli io tap <x,y>` | Single touch on a ref from `dump ui`, or at coordinates |
-| **Long Press** | `mobilecli io longpress <x,y> --duration <ms>` | Press and hold for a duration |
+| **Long Press** | `mobilecli io longpress <x,y \| @ref> --duration <ms>` | Press and hold for a duration |
 | **Swipe** | `mobilecli io swipe <x1,y1,x2,y2>` | Drag from start to end coordinates |
 | **Pinch** | `mobilecli io pinch [x,y] --direction in\|out` | Two-finger zoom out (`in`) or in (`out`), around x,y or the screen center |
 | **Type Text** | `mobilecli io text "<text>"` | Send raw text to the focused field |

--- a/skills/mobilecli/reference.md
+++ b/skills/mobilecli/reference.md
@@ -86,8 +86,9 @@ All commands support the global `--device <id>` flag to specify the target devic
   mobilecli io tap --device <device-id> @e5
   mobilecli io tap --device <device-id> 150,300
   ```
-* **Long Press**:
+* **Long Press** (ref from the latest `dump ui`, or coordinates):
   ```bash
+  mobilecli io longpress --device <device-id> @e5 --duration 2000
   mobilecli io longpress --device <device-id> 150,300 --duration 2000
   ```
 * **Swipe**:


### PR DESCRIPTION
`mobilecli io tap @e5` worked. `mobilecli io longpress @e5` did not, and failed with a coordinate format error.

The two commands each parsed their own argument, and only tap was taught about refs when they were added. They now share one parser, so they cannot drift apart again, and `LongPressRequest` carries a `Ref` that resolves through the same `resolveRefTapPoint` tap uses.

Element refs stay a CLI feature. Neither `device.io.tap` nor `device.io.longpress` accepts one over JSON-RPC today, and this does not change that.

## Test plan

On a Pixel 9 Pro emulator:

- [x] `io longpress @e39` on an app icon opens its context menu (App info, Pause app, Widgets)
- [x] `io longpress @e9999` reports that the ref is not on the current screen
- [x] `io longpress 150` is rejected, and the message now mentions refs as well as coordinates
- [x] `io longpress 540,1500 --duration 400` still works
- [x] `io tap @e1` still works
- [x] unit tests for the parser: coordinates, spaces around them, a ref, and four malformed arguments
- [x] `go build ./...`, `go test ./...`, `gofmt`