### PR TITLE
refactor: clear every dupl finding from the linter

### DIFF
--- a/cli/clipboard.go
+++ b/cli/clipboard.go
@@ -1,3 +1,4 @@
+//nolint:dupl // cobra command declarations for unrelated command groups share a shape, not logic
 package cli
 
 import (

--- a/cli/crashes.go
+++ b/cli/crashes.go
@@ -1,3 +1,4 @@
+//nolint:dupl // cobra command declarations for unrelated command groups share a shape, not logic
 package cli
 
 import (

--- a/commands/apps.go
+++ b/commands/apps.go
@@ -86,17 +86,9 @@ type ForegroundAppRequest struct {
 
 // ForegroundAppCommand gets the currently foreground app on a device
 func ForegroundAppCommand(req ForegroundAppRequest) *CommandResponse {
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	// start agent if needed (for WDA)
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	app, err := targetDevice.GetForegroundApp()

--- a/commands/clipboard.go
+++ b/commands/clipboard.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"fmt"
-
-	"github.com/mobile-next/mobilecli/devices"
 )
 
 type ClipboardGetRequest struct {
@@ -20,16 +18,9 @@ type ClipboardResult struct {
 }
 
 func ClipboardGetCommand(req ClipboardGetRequest) *CommandResponse {
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	text, err := targetDevice.GetClipboard()
@@ -41,16 +32,9 @@ func ClipboardGetCommand(req ClipboardGetRequest) *CommandResponse {
 }
 
 func ClipboardSetCommand(req ClipboardSetRequest) *CommandResponse {
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	err = targetDevice.SetClipboard(req.Text)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -227,3 +227,21 @@ func getDeviceIDList(devices []devices.ControllableDevice) string {
 	}
 	return fmt.Sprintf("[%s]", strings.Join(ids, ", "))
 }
+
+// FindDeviceWithAgent finds a device by ID (or auto-selects one) and makes sure
+// its agent is running, so callers can immediately drive the device.
+func FindDeviceWithAgent(deviceID string) (devices.ControllableDevice, error) {
+	targetDevice, err := FindDeviceOrAutoSelect(deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("error finding device: %w", err)
+	}
+
+	err = targetDevice.StartAgent(devices.StartAgentConfig{
+		Hook: GetShutdownHook(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to start agent on device %s: %w", targetDevice.ID(), err)
+	}
+
+	return targetDevice, nil
+}

--- a/commands/dump.go
+++ b/commands/dump.go
@@ -26,17 +26,9 @@ type DumpUIResponse struct {
 // DumpUICommand starts an agent and dumps the UI tree from the specified device
 func DumpUICommand(req DumpUIRequest) *CommandResponse {
 	// Find the target device
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %w", err))
-	}
-
-	// Start agent if needed
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %w", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	var response DumpUIResponse

--- a/commands/info.go
+++ b/commands/info.go
@@ -12,16 +12,9 @@ type DeviceInfoResponse struct {
 }
 
 func InfoCommand(deviceID string) *CommandResponse {
-	targetDevice, err := FindDeviceOrAutoSelect(deviceID)
+	targetDevice, err := FindDeviceWithAgent(deviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error starting agent: %v", err))
+		return NewErrorResponse(err)
 	}
 
 	info, err := targetDevice.Info()

--- a/commands/input.go
+++ b/commands/input.go
@@ -139,16 +139,9 @@ func TapCommand(req TapRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("x and y coordinates must be non-negative, got x=%d, y=%d", req.X, req.Y))
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	x, y := req.X, req.Y
@@ -205,16 +198,9 @@ func LongPressCommand(req LongPressRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("x and y coordinates must be non-negative, got x=%d, y=%d", req.X, req.Y))
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	x, y := req.X, req.Y
@@ -241,16 +227,9 @@ func TextCommand(req TextRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("text is required"))
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	err = targetDevice.SendKeys(req.Text)
@@ -269,16 +248,9 @@ func ButtonCommand(req ButtonRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("button name is required"))
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	err = targetDevice.PressButton(req.Button)
@@ -297,16 +269,9 @@ func GestureCommand(req GestureRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("actions array is required and cannot be empty"))
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	// Convert []any to []devicekit.TapAction
@@ -340,16 +305,9 @@ func PinchCommand(req PinchRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("direction must be %q or %q, got %q", PinchDirectionIn, PinchDirectionOut, req.Direction))
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	x, y := req.X, req.Y
@@ -388,16 +346,9 @@ func screenCenter(device devices.ControllableDevice) (int, int, error) {
 
 // SwipeCommand performs a swipe operation on the specified device
 func SwipeCommand(req SwipeRequest) *CommandResponse {
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	err = targetDevice.Swipe(req.X1, req.Y1, req.X2, req.Y2, req.Duration)

--- a/commands/keys.go
+++ b/commands/keys.go
@@ -83,16 +83,9 @@ func KeysCommand(req KeysRequest) *CommandResponse {
 		combos[i] = combo
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	err = targetDevice.PressKeys(combos)

--- a/commands/orientation.go
+++ b/commands/orientation.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"fmt"
-
-	"github.com/mobile-next/mobilecli/devices"
 )
 
 // OrientationGetRequest represents the request for getting device orientation
@@ -24,17 +22,9 @@ type OrientationResponse struct {
 
 // OrientationGetCommand gets the current device orientation
 func OrientationGetCommand(req OrientationGetRequest) *CommandResponse {
-	device, err := FindDeviceOrAutoSelect(req.DeviceID)
+	device, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
 		return NewErrorResponse(err)
-	}
-
-	// start agent if needed
-	err = device.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", device.ID(), err))
 	}
 
 	orientation, err := device.GetOrientation()
@@ -56,17 +46,9 @@ func OrientationSetCommand(req OrientationSetRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("invalid orientation value '%s', must be 'portrait' or 'landscape'", req.Orientation))
 	}
 
-	device, err := FindDeviceOrAutoSelect(req.DeviceID)
+	device, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
 		return NewErrorResponse(err)
-	}
-
-	// start agent if needed
-	err = device.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", device.ID(), err))
 	}
 
 	err = device.SetOrientation(req.Orientation)

--- a/commands/url.go
+++ b/commands/url.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"fmt"
-
-	"github.com/mobile-next/mobilecli/devices"
 )
 
 // URLRequest represents the parameters for a URL opening command
@@ -18,16 +16,9 @@ func URLCommand(req URLRequest) *CommandResponse {
 		return NewErrorResponse(fmt.Errorf("URL is required"))
 	}
 
-	targetDevice, err := FindDeviceOrAutoSelect(req.DeviceID)
+	targetDevice, err := FindDeviceWithAgent(req.DeviceID)
 	if err != nil {
-		return NewErrorResponse(fmt.Errorf("error finding device: %v", err))
-	}
-
-	err = targetDevice.StartAgent(devices.StartAgentConfig{
-		Hook: GetShutdownHook(),
-	})
-	if err != nil {
-		return NewErrorResponse(fmt.Errorf("failed to start agent on device %s: %v", targetDevice.ID(), err))
+		return NewErrorResponse(err)
 	}
 
 	err = targetDevice.OpenURL(req.URL)

--- a/devices/adb_test.go
+++ b/devices/adb_test.go
@@ -72,24 +72,35 @@ func writeLenPrefixed(t *testing.T, conn net.Conn, payload string) {
 	}
 }
 
-func TestADB_Shell_UsesTransportOnSameConnection(t *testing.T) {
-	host, port, closeFn := startFakeADBServer(t, func(conn net.Conn) {
+// serveTransportThenService answers the two-step adb handshake a device command
+// makes on a single connection — select the device, then request the service —
+// and replies with output.
+func serveTransportThenService(t *testing.T, serial, service, output string) func(net.Conn) {
+	t.Helper()
+
+	return func(conn net.Conn) {
 		defer conn.Close()
 
 		got := readADBService(t, conn)
-		if got != "host:transport:serial-123" {
-			t.Fatalf("expected transport select, got %q", got)
+		if got != "host:transport:"+serial {
+			t.Errorf("expected transport select, got %q", got)
+			return
 		}
 		writeOKAY(t, conn)
 
 		got = readADBService(t, conn)
-		if got != "shell:echo hi" {
-			t.Fatalf("expected shell, got %q", got)
+		if got != service {
+			t.Errorf("expected %q, got %q", service, got)
+			return
 		}
 		writeOKAY(t, conn)
 
-		_, _ = conn.Write([]byte("hi\n"))
-	})
+		_, _ = conn.Write([]byte(output))
+	}
+}
+
+func TestADB_Shell_UsesTransportOnSameConnection(t *testing.T) {
+	host, port, closeFn := startFakeADBServer(t, serveTransportThenService(t, "serial-123", "shell:echo hi", "hi\n"))
 	defer closeFn()
 
 	adb := NewADB(host, port)
@@ -184,23 +195,7 @@ func TestADB_ResponseLimit(t *testing.T) {
 }
 
 func TestADB_ExecOut_UsesTransportOnSameConnection(t *testing.T) {
-	host, port, closeFn := startFakeADBServer(t, func(conn net.Conn) {
-		defer conn.Close()
-
-		got := readADBService(t, conn)
-		if got != "host:transport:serial-123" {
-			t.Fatalf("expected transport select, got %q", got)
-		}
-		writeOKAY(t, conn)
-
-		got = readADBService(t, conn)
-		if got != "exec:cmd" {
-			t.Fatalf("expected exec, got %q", got)
-		}
-		writeOKAY(t, conn)
-
-		_, _ = conn.Write([]byte("out\n"))
-	})
+	host, port, closeFn := startFakeADBServer(t, serveTransportThenService(t, "serial-123", "exec:cmd", "out\n"))
 	defer closeFn()
 
 	adb := NewADB(host, port)

--- a/devices/android_display_test.go
+++ b/devices/android_display_test.go
@@ -2,12 +2,28 @@ package devices
 
 import "testing"
 
+// displayIdParseCase is one "given this command output, expect this display id" case.
+type displayIdParseCase struct {
+	name   string
+	output string
+	want   string
+}
+
+// expectDisplayIdParsedFromOutput runs every case through parse and reports mismatches.
+func expectDisplayIdParsedFromOutput(t *testing.T, parserName string, parse func(string) string, cases []displayIdParseCase) {
+	t.Helper()
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parse(tt.output); got != tt.want {
+				t.Errorf("%s() = %v, want %v", parserName, got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_parseDisplayIdFromCmdDisplay(t *testing.T) {
-	tests := []struct {
-		name   string
-		output string
-		want   string
-	}{
+	expectDisplayIdParsedFromOutput(t, "parseDisplayIdFromCmdDisplay", parseDisplayIdFromCmdDisplay, []displayIdParseCase{
 		{
 			name: "single display ON",
 			output: `Displays:
@@ -26,67 +42,43 @@ Display id 3: DisplayInfo{"Second Screen", displayId 3, state OFF, type INTERNAL
 			output: "some random text",
 			want:   "",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := parseDisplayIdFromCmdDisplay(tt.output); got != tt.want {
-				t.Errorf("parseDisplayIdFromCmdDisplay() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	})
 }
 
 func Test_parseDisplayIdFromDumpsysViewport(t *testing.T) {
-	tests := []struct {
-		name    string
-		dumpsys string
-		want    string
-	}{
+	expectDisplayIdParsedFromOutput(t, "parseDisplayIdFromDumpsysViewport", parseDisplayIdFromDumpsysViewport, []displayIdParseCase{
 		{
 			name: "single display active",
-			dumpsys: `DISPLAY MANAGER (dumpsys display)
+			output: `DISPLAY MANAGER (dumpsys display)
   mViewports=[DisplayViewport{type=INTERNAL, valid=true, isActive=true, displayId=0, uniqueId='local:4619827259835644672', physicalPort=0}]`,
 			want: "4619827259835644672",
 		},
 		{
 			name: "two displays first active",
-			dumpsys: `DISPLAY MANAGER (dumpsys display)
+			output: `DISPLAY MANAGER (dumpsys display)
   mViewports=[DisplayViewport{type=INTERNAL, valid=true, isActive=true, displayId=0, uniqueId='local:4619827259835644672', physicalPort=0}, DisplayViewport{type=INTERNAL, valid=true, isActive=false, displayId=3, uniqueId='local:4619827551948147201', physicalPort=1}]`,
 			want: "4619827259835644672",
 		},
 		{
-			name:    "invalid input",
-			dumpsys: "some random text",
-			want:    "",
+			name:   "invalid input",
+			output: "some random text",
+			want:   "",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := parseDisplayIdFromDumpsysViewport(tt.dumpsys); got != tt.want {
-				t.Errorf("parseDisplayIdFromDumpsysViewport() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	})
 }
 
 func Test_parseDisplayIdFromDumpsysState(t *testing.T) {
-	tests := []struct {
-		name    string
-		dumpsys string
-		want    string
-	}{
+	expectDisplayIdParsedFromOutput(t, "parseDisplayIdFromDumpsysState", parseDisplayIdFromDumpsysState, []displayIdParseCase{
 		{
 			name: "single display ON",
-			dumpsys: `Display States: size=1
+			output: `Display States: size=1
   Display Id=0
   Display State=ON`,
 			want: "0",
 		},
 		{
 			name: "two displays first ON",
-			dumpsys: `Display States: size=2
+			output: `Display States: size=2
   Display Id=0
   Display State=ON
   Display Id=3
@@ -94,17 +86,9 @@ func Test_parseDisplayIdFromDumpsysState(t *testing.T) {
 			want: "0",
 		},
 		{
-			name:    "invalid input",
-			dumpsys: "some random text",
-			want:    "",
+			name:   "invalid input",
+			output: "some random text",
+			want:   "",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := parseDisplayIdFromDumpsysState(tt.dumpsys); got != tt.want {
-				t.Errorf("parseDisplayIdFromDumpsysState() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	})
 }

--- a/devices/android_webview.go
+++ b/devices/android_webview.go
@@ -331,44 +331,12 @@ func (d *AndroidDevice) WebViewContent(webviewID string) (string, error) {
 	return content, nil
 }
 
-// ensureReturnExpression turns a value expression into a statement body that
-// returns that value, so the agent's eval wrapper can capture it. A bare
-// expression — even an IIFE that internally uses ';', '{' or newlines — must be
-// wrapped; only skip wrapping when the caller already supplied a top-level
-// "return". A trailing ';' is stripped so the wrapped form stays valid.
-func ensureReturnExpression(expression string) string {
-	trimmed := strings.TrimSpace(expression)
-	if strings.HasPrefix(trimmed, "return ") || strings.HasPrefix(trimmed, "return(") {
-		return expression
-	}
-	trimmed = strings.TrimRight(trimmed, " \t\r\n;")
-	return "return (" + trimmed + ")"
-}
-
 func (d *AndroidDevice) WebViewEvaluate(webviewID, expression string, args []any) (any, error) {
 	port, err := d.getWebViewPort()
 	if err != nil {
 		return nil, err
 	}
-	params := map[string]any{
-		"id":         webviewID,
-		"expression": ensureReturnExpression(expression),
-	}
-	if len(args) > 0 {
-		params["args"] = args
-	}
-	raw, err := agentRequest(port, "device.webview.evaluate", params)
-	if err != nil {
-		return nil, err
-	}
-	// agent returns {"result": <value>} — unwrap one level
-	var wrapper struct {
-		Result any `json:"result"`
-	}
-	if err := json.Unmarshal(raw, &wrapper); err != nil {
-		return nil, fmt.Errorf("parse evaluate result: %w", err)
-	}
-	return wrapper.Result, nil
+	return webViewEvaluate(port, webviewID, expression, args)
 }
 
 func (d *AndroidDevice) WebViewWaitForLoadState(webviewID, state string, timeoutMs int) error {
@@ -376,16 +344,5 @@ func (d *AndroidDevice) WebViewWaitForLoadState(webviewID, state string, timeout
 	if err != nil {
 		return err
 	}
-	const agentDefaultMs = 30_000
-	waitMs := agentDefaultMs
-	if timeoutMs > 0 {
-		waitMs = timeoutMs
-	}
-	params := map[string]any{"id": webviewID, "timeout": waitMs}
-	if state != "" {
-		params["state"] = state
-	}
-	httpTimeout := time.Duration(waitMs)*time.Millisecond + 5*time.Second
-	_, err = agentRequestWithTimeout(port, "device.webview.waitForLoadState", params, httpTimeout)
-	return err
+	return webViewWaitForLoadState(port, webviewID, state, timeoutMs)
 }

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -920,37 +920,7 @@ func (d *IOSDevice) ListApps(onlyLaunchable bool) ([]InstalledAppInfo, error) {
 }
 
 func (d *IOSDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
-	// get active app info from WDA
-	activeApp, err := d.deviceKitClient.GetActiveAppInfo()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get active app info: %w", err)
-	}
-
-	// get all installed apps to enrich with version information
-	apps, err := d.ListApps(true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list apps: %w", err)
-	}
-
-	// find the matching app to get full details
-	for _, app := range apps {
-		if app.PackageName == activeApp.BundleID {
-			return &ForegroundAppInfo{
-				PackageName: app.PackageName,
-				AppName:     app.AppName,
-				Version:     app.Version,
-				Activity:    activeApp.ViewController,
-			}, nil
-		}
-	}
-
-	// if app not found in list (e.g., system app), return info from WDA only
-	return &ForegroundAppInfo{
-		PackageName: activeApp.BundleID,
-		AppName:     activeApp.Name,
-		Version:     "",
-		Activity:    activeApp.ViewController,
-	}, nil
+	return wdaForegroundApp(d.deviceKitClient, d.ListApps)
 }
 
 func (d *IOSDevice) Info() (*FullDeviceInfo, error) {

--- a/devices/ios_webview.go
+++ b/devices/ios_webview.go
@@ -256,24 +256,13 @@ func (s *SimulatorDevice) WebViewContent(wvID string) (string, error) {
 }
 
 // WebViewWaitForLoadState blocks until the webview reaches the given load state.
-// timeoutMs of 0 uses the agent's default (30s).
+// timeoutMs of 0 uses the agent's default.
 func (s *SimulatorDevice) WebViewWaitForLoadState(wvID, state string, timeoutMs int) error {
 	port, err := s.ensureIOSAgentReady()
 	if err != nil {
 		return err
 	}
-	const agentDefaultMs = 30_000
-	waitMs := agentDefaultMs
-	if timeoutMs > 0 {
-		waitMs = timeoutMs
-	}
-	params := map[string]any{"id": wvID, "timeout": waitMs}
-	if state != "" {
-		params["state"] = state
-	}
-	httpTimeout := time.Duration(waitMs)*time.Millisecond + 5*time.Second
-	_, err = agentRequestWithTimeout(port, "device.webview.waitForLoadState", params, httpTimeout)
-	return err
+	return webViewWaitForLoadState(port, wvID, state, timeoutMs)
 }
 
 // WebViewGoto navigates the webview identified by wvID to url.
@@ -292,24 +281,7 @@ func (s *SimulatorDevice) WebViewEvaluate(wvID, expression string, args []any) (
 	if err != nil {
 		return nil, err
 	}
-	params := map[string]any{
-		"id":         wvID,
-		"expression": ensureReturnExpression(expression),
-	}
-	if len(args) > 0 {
-		params["args"] = args
-	}
-	raw, err := agentRequest(port, "device.webview.evaluate", params)
-	if err != nil {
-		return nil, err
-	}
-	var wrapper struct {
-		Result any `json:"result"`
-	}
-	if err := json.Unmarshal(raw, &wrapper); err != nil {
-		return nil, fmt.Errorf("parse evaluate result: %w", err)
-	}
-	return wrapper.Result, nil
+	return webViewEvaluate(port, wvID, expression, args)
 }
 
 // ListWebViews returns all embedded WKWebViews found in the foreground simulator app.

--- a/devices/simulator.go
+++ b/devices/simulator.go
@@ -658,37 +658,7 @@ func (s *SimulatorDevice) ListApps(onlyLaunchable bool) ([]InstalledAppInfo, err
 }
 
 func (s *SimulatorDevice) GetForegroundApp() (*ForegroundAppInfo, error) {
-	// get active app info from WDA
-	activeApp, err := s.deviceKitClient.GetActiveAppInfo()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get active app info: %w", err)
-	}
-
-	// get all installed apps to enrich with version information
-	apps, err := s.ListApps(true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list apps: %w", err)
-	}
-
-	// find the matching app to get full details
-	for _, app := range apps {
-		if app.PackageName == activeApp.BundleID {
-			return &ForegroundAppInfo{
-				PackageName: app.PackageName,
-				AppName:     app.AppName,
-				Version:     app.Version,
-				Activity:    activeApp.ViewController,
-			}, nil
-		}
-	}
-
-	// if app not found in list (e.g., system app), return info from WDA only
-	return &ForegroundAppInfo{
-		PackageName: activeApp.BundleID,
-		AppName:     activeApp.Name,
-		Version:     "",
-		Activity:    activeApp.ViewController,
-	}, nil
+	return wdaForegroundApp(s.deviceKitClient, s.ListApps)
 }
 
 func (s *SimulatorDevice) Info() (*FullDeviceInfo, error) {

--- a/devices/wda_foreground_app.go
+++ b/devices/wda_foreground_app.go
@@ -1,0 +1,44 @@
+package devices
+
+import (
+	"fmt"
+
+	"github.com/mobile-next/mobilecli/devices/devicekit"
+)
+
+// wdaForegroundApp asks WDA which app is in the foreground and enriches the
+// answer with version details from the device's installed-app list. Shared by
+// the physical-device and simulator implementations, which both talk to WDA.
+func wdaForegroundApp(client *devicekit.DeviceKitClient, listApps func(onlyLaunchable bool) ([]InstalledAppInfo, error)) (*ForegroundAppInfo, error) {
+	// get active app info from WDA
+	activeApp, err := client.GetActiveAppInfo()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active app info: %w", err)
+	}
+
+	// get all installed apps to enrich with version information
+	apps, err := listApps(true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list apps: %w", err)
+	}
+
+	// find the matching app to get full details
+	for _, app := range apps {
+		if app.PackageName == activeApp.BundleID {
+			return &ForegroundAppInfo{
+				PackageName: app.PackageName,
+				AppName:     app.AppName,
+				Version:     app.Version,
+				Activity:    activeApp.ViewController,
+			}, nil
+		}
+	}
+
+	// if app not found in list (e.g., system app), return info from WDA only
+	return &ForegroundAppInfo{
+		PackageName: activeApp.BundleID,
+		AppName:     activeApp.Name,
+		Version:     "",
+		Activity:    activeApp.ViewController,
+	}, nil
+}

--- a/devices/webview_agent.go
+++ b/devices/webview_agent.go
@@ -1,0 +1,74 @@
+package devices
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// webViewAgentDefaultTimeoutMs mirrors the agent's own default wait, and is used
+// when the caller does not ask for a specific timeout.
+const webViewAgentDefaultTimeoutMs = 30_000
+
+// ensureReturnExpression turns a value expression into a statement body that
+// returns that value, so the agent's eval wrapper can capture it. A bare
+// expression — even an IIFE that internally uses ';', '{' or newlines — must be
+// wrapped; only skip wrapping when the caller already supplied a top-level
+// "return". A trailing ';' is stripped so the wrapped form stays valid.
+func ensureReturnExpression(expression string) string {
+	trimmed := strings.TrimSpace(expression)
+	if strings.HasPrefix(trimmed, "return ") || strings.HasPrefix(trimmed, "return(") {
+		return expression
+	}
+	trimmed = strings.TrimRight(trimmed, " \t\r\n;")
+	return "return (" + trimmed + ")"
+}
+
+// webViewEvaluate runs expression in the webview and returns the JS result value.
+// Both the Android and iOS agents speak the same webview protocol, so the only
+// per-platform difference is which port the agent is listening on.
+func webViewEvaluate(port int, webviewID, expression string, args []any) (any, error) {
+	params := map[string]any{
+		"id":         webviewID,
+		"expression": ensureReturnExpression(expression),
+	}
+	if len(args) > 0 {
+		params["args"] = args
+	}
+
+	raw, err := agentRequest(port, "device.webview.evaluate", params)
+	if err != nil {
+		return nil, err
+	}
+
+	// agent returns {"result": <value>} — unwrap one level
+	var wrapper struct {
+		Result any `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return nil, fmt.Errorf("parse evaluate result: %w", err)
+	}
+
+	return wrapper.Result, nil
+}
+
+// webViewWaitForLoadState blocks until the webview reaches the given load state.
+// timeoutMs of 0 uses the agent's default.
+func webViewWaitForLoadState(port int, webviewID, state string, timeoutMs int) error {
+	waitMs := webViewAgentDefaultTimeoutMs
+	if timeoutMs > 0 {
+		waitMs = timeoutMs
+	}
+
+	params := map[string]any{"id": webviewID, "timeout": waitMs}
+	if state != "" {
+		params["state"] = state
+	}
+
+	// give the http call a margin over the agent-side wait, so the agent is the
+	// one that times out and reports why
+	httpTimeout := time.Duration(waitMs)*time.Millisecond + 5*time.Second
+	_, err := agentRequestWithTimeout(port, "device.webview.waitForLoadState", params, httpTimeout)
+	return err
+}

--- a/server/server.go
+++ b/server/server.go
@@ -383,10 +383,7 @@ func handleDevicesList(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.DevicesCommand(opts, commands.GetFleetToken())
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleScreenshot(params json.RawMessage) (any, error) {
@@ -612,11 +609,7 @@ func handleClipboardGet(params json.RawMessage) (any, error) {
 	response := commands.ClipboardGetCommand(commands.ClipboardGetRequest{
 		DeviceID: clipboardParams.DeviceID,
 	})
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleClipboardSet(params json.RawMessage) (any, error) {
@@ -899,11 +892,7 @@ func handleDeviceInfo(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.InfoCommand(infoParams.DeviceID)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleIoOrientationGet(params json.RawMessage) (any, error) {
@@ -921,11 +910,7 @@ func handleIoOrientationGet(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.OrientationGetCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleIoOrientationSet(params json.RawMessage) (any, error) {
@@ -972,11 +957,7 @@ func handleLocationSet(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.LocationSetCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleLocationClear(params json.RawMessage) (any, error) {
@@ -1039,11 +1020,7 @@ func handleDeviceBoot(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.BootCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleDeviceShutdown(params json.RawMessage) (any, error) {
@@ -1061,11 +1038,7 @@ func handleDeviceShutdown(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.ShutdownCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleDeviceReboot(params json.RawMessage) (any, error) {
@@ -1083,11 +1056,7 @@ func handleDeviceReboot(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.RebootCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleDumpUI(params json.RawMessage) (any, error) {
@@ -1107,11 +1076,7 @@ func handleDumpUI(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.DumpUICommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleAppsLaunch(params json.RawMessage) (any, error) {
@@ -1132,11 +1097,7 @@ func handleAppsLaunch(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.LaunchAppCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleAppsTerminate(params json.RawMessage) (any, error) {
@@ -1155,11 +1116,7 @@ func handleAppsTerminate(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.TerminateAppCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleAppsList(params json.RawMessage) (any, error) {
@@ -1175,11 +1132,7 @@ func handleAppsList(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.ListAppsCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleAppsForeground(params json.RawMessage) (any, error) {
@@ -1195,11 +1148,7 @@ func handleAppsForeground(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.ForegroundAppCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleAppsInstall(params json.RawMessage) (any, error) {
@@ -1225,11 +1174,7 @@ func handleAppsInstall(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.InstallAppCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleAppsClear(params json.RawMessage) (any, error) {
@@ -1252,11 +1197,7 @@ func handleAppsClear(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.ClearAppCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleAppsUninstall(params json.RawMessage) (any, error) {
@@ -1283,11 +1224,7 @@ func handleAppsUninstall(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.UninstallAppCommand(req)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 // screenRecordReadyTimeout bounds how long handleScreenRecord waits for the
@@ -1418,11 +1355,7 @@ func handleCrashesList(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.CrashesListCommand(p.DeviceID)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleCrashesGet(params json.RawMessage) (any, error) {
@@ -1438,11 +1371,7 @@ func handleCrashesGet(params json.RawMessage) (any, error) {
 	}
 
 	response := commands.CrashesGetCommand(p.DeviceID, p.ID)
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleServerInfo(params json.RawMessage) (any, error) {
@@ -2000,10 +1929,7 @@ func handleAppsPath(params json.RawMessage) (any, error) {
 		DeviceID: p.DeviceID,
 		BundleID: p.BundleID,
 	})
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleFsLs(params json.RawMessage) (any, error) {
@@ -2019,10 +1945,7 @@ func handleFsLs(params json.RawMessage) (any, error) {
 		BundleID:   p.BundleID,
 		RemotePath: p.RemotePath,
 	})
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleFsPull(params json.RawMessage) (any, error) {
@@ -2123,10 +2046,7 @@ func handleFsPush(params json.RawMessage) (any, error) {
 		LocalPath:  tmpPath,
 		RemotePath: p.RemotePath,
 	})
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleFsMkdir(params json.RawMessage) (any, error) {
@@ -2144,10 +2064,7 @@ func handleFsMkdir(params json.RawMessage) (any, error) {
 		RemotePath: p.RemotePath,
 		Parents:    p.Parents,
 	})
-	if response.Status == "error" {
-		return nil, fmt.Errorf("%s", response.Error)
-	}
-	return response.Data, nil
+	return commandResult(response)
 }
 
 func handleFsRm(params json.RawMessage) (any, error) {
@@ -2165,8 +2082,15 @@ func handleFsRm(params json.RawMessage) (any, error) {
 		RemotePath: p.RemotePath,
 		Recursive:  p.Recursive,
 	})
+	return commandResult(response)
+}
+
+// commandResult converts a command response into the (result, error) pair a
+// json-rpc handler returns.
+func commandResult(response *commands.CommandResponse) (any, error) {
 	if response.Status == "error" {
 		return nil, fmt.Errorf("%s", response.Error)
 	}
+
 	return response.Data, nil
 }

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -166,46 +166,38 @@ func TestWebSocket_MethodNotFound(t *testing.T) {
 	assert.Equal(t, "Method not found", errorMap["message"])
 }
 
-func TestWebSocket_InvalidJSON(t *testing.T) {
+// expectJSONRPCErrorForMessage sends one raw websocket message and asserts the
+// json-rpc error the server answers with.
+func expectJSONRPCErrorForMessage(t *testing.T, messageType int, payload string, wantCode int, wantMessage, wantData string) {
+	t.Helper()
+
 	server, wsURL := setupTestServer(false)
 	defer server.Close()
 
 	conn := connectWebSocket(t, wsURL)
 	defer conn.Close()
 
-	err := conn.WriteMessage(websocket.TextMessage, []byte("invalid json"))
-	require.NoError(t, err)
+	require.NoError(t, conn.WriteMessage(messageType, []byte(payload)))
 
 	resp := readJSONRPCResponse(t, conn)
 
 	assert.Equal(t, "2.0", resp.JSONRPC)
-	assert.NotNil(t, resp.Error)
+	require.NotNil(t, resp.Error)
 
 	errorMap := resp.Error.(map[string]any)
-	assert.Equal(t, float64(ErrCodeParseError), errorMap["code"])
-	assert.Equal(t, errTitleParseError, errorMap["message"])
-	assert.Equal(t, errMsgParseError, errorMap["data"])
+	assert.Equal(t, float64(wantCode), errorMap["code"])
+	assert.Equal(t, wantMessage, errorMap["message"])
+	assert.Equal(t, wantData, errorMap["data"])
+}
+
+func TestWebSocket_InvalidJSON(t *testing.T) {
+	expectJSONRPCErrorForMessage(t, websocket.TextMessage, "invalid json",
+		ErrCodeParseError, errTitleParseError, errMsgParseError)
 }
 
 func TestWebSocket_BinaryMessageRejected(t *testing.T) {
-	server, wsURL := setupTestServer(false)
-	defer server.Close()
-
-	conn := connectWebSocket(t, wsURL)
-	defer conn.Close()
-
-	err := conn.WriteMessage(websocket.BinaryMessage, []byte("binary data"))
-	require.NoError(t, err)
-
-	resp := readJSONRPCResponse(t, conn)
-
-	assert.Equal(t, "2.0", resp.JSONRPC)
-	assert.NotNil(t, resp.Error)
-
-	errorMap := resp.Error.(map[string]any)
-	assert.Equal(t, float64(ErrCodeInvalidRequest), errorMap["code"])
-	assert.Equal(t, errTitleInvalidReq, errorMap["message"])
-	assert.Equal(t, errMsgTextOnly, errorMap["data"])
+	expectJSONRPCErrorForMessage(t, websocket.BinaryMessage, "binary data",
+		ErrCodeInvalidRequest, errTitleInvalidReq, errMsgTextOnly)
 }
 
 func TestWebSocket_MultipleRequests(t *testing.T) {


### PR DESCRIPTION
`golangci-lint`'s `dupl` reported 19 findings across `commands/`, `devices/`, `server/` and three test files. This clears all of them. **No behaviour change** — net −338 lines.

## What was duplicated, and what replaced it

| Duplication | Fix |
|---|---|
| 17× "find device, then start its agent" (8 lines each) | `FindDeviceWithAgent` — `commands/commands.go` |
| 23× "unwrap `CommandResponse` into `(result, error)`" | `commandResult()` — `server/server.go` |
| Android/iOS `WebViewEvaluate` + `WebViewWaitForLoadState` | port-based helpers in new `devices/webview_agent.go` |
| `IOSDevice`/`SimulatorDevice` `GetForegroundApp` | `wdaForegroundApp()` — new `devices/wda_foreground_app.go` |
| 3× display-id parser table tests | `expectDisplayIdParsedFromOutput()` |
| 2× adb transport handshake tests | `serveTransportThenService()` |
| 2× websocket error-response tests | `expectJSONRPCErrorForMessage()` |

The two webview methods only differed in how each platform resolves the agent port — both agents already speak the same webview protocol. `GetForegroundApp` was byte-identical between the two iOS device types apart from the receiver.

## Deliberately not collapsed

- **`cli/clipboard.go` vs `cli/crashes.go`** — unrelated command groups that only share cobra's declaration shape. There's no logic to extract, so they carry a `//nolint:dupl` naming that reason, matching how the repo handles its other false positives.
- **`screenrecord.go`** — passes an extra `OnProgress` to `StartAgent`.
- **`screenshot.go`** — validates input between finding the device and starting the agent; collapsing it would reorder the work.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] `make lint` — `dupl` now reports 0 (the 330 remaining errcheck/goconst/gocyclo/gosec issues are pre-existing and untouched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improved Device Handling**
  - Device-based commands now consistently locate the requested or automatically selected device and ensure its agent is available before running.
  - Errors from device and agent lookup are reported more directly.

- **WebView Improvements**
  - JavaScript evaluation and load-state waiting now provide consistent expression handling, argument forwarding, timeout behavior, and result parsing.

- **Foreground App Information**
  - Foreground app details are resolved more consistently, including installed-app metadata when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->