### PR TITLE
fix: clear gosec directory permission and integer conversion findings

### DIFF
--- a/devices/android_fs.go
+++ b/devices/android_fs.go
@@ -88,7 +88,7 @@ func (d *AndroidDevice) PullFile(remotePath, localPath string) error {
 		}
 		return fmt.Errorf("pull failed: %w", err)
 	}
-	return os.WriteFile(localPath, data, 0644)
+	return os.WriteFile(localPath, data, 0600)
 }
 
 func (d *AndroidDevice) ListFiles(bundleID, remotePath string) ([]FileEntry, error) {

--- a/devices/ios.go
+++ b/devices/ios.go
@@ -979,7 +979,7 @@ func (d *IOSDevice) sendAvcControl(method string, params map[string]any) error {
 	}
 
 	buf := make([]byte, 4+len(msg))
-	binary.BigEndian.PutUint32(buf, uint32(len(msg)))
+	binary.BigEndian.PutUint32(buf, uint32(len(msg))) //nolint:gosec // length bounded by maxAvcControlMessageSize above
 	copy(buf[4:], msg)
 
 	d.avcWriteMu.Lock()

--- a/devices/ios/port-forwarding.go
+++ b/devices/ios/port-forwarding.go
@@ -47,7 +47,7 @@ func (pf *PortForwarder) Forward(srcPort, dstPort int) error {
 		return fmt.Errorf("failed to get device %s: %w", pf.udid, err)
 	}
 
-	connListener, err := forward.Forward(device, uint16(srcPort), uint16(dstPort))
+	connListener, err := forward.Forward(device, uint16(srcPort), uint16(dstPort)) //nolint:gosec // ports validated to be 0-65535 above
 	if err != nil {
 		return fmt.Errorf("failed to create port forwarder: %w", err)
 	}

--- a/devices/simulator_fs.go
+++ b/devices/simulator_fs.go
@@ -104,7 +104,7 @@ func (s *SimulatorDevice) PullFile(remotePath, localPath string) error {
 	if err != nil {
 		return fmt.Errorf("pull failed: %w", err)
 	}
-	return os.WriteFile(localPath, data, 0644)
+	return os.WriteFile(localPath, data, 0600)
 }
 
 func (s *SimulatorDevice) PushFile(localPath, remotePath string) error {
@@ -115,7 +115,7 @@ func (s *SimulatorDevice) PushFile(localPath, remotePath string) error {
 	if err != nil {
 		return fmt.Errorf("read local file failed: %w", err)
 	}
-	return os.WriteFile(remotePath, data, 0644)
+	return os.WriteFile(remotePath, data, 0600)
 }
 
 func (s *SimulatorDevice) Mkdir(bundleID, remotePath string, parents bool) error {
@@ -123,9 +123,9 @@ func (s *SimulatorDevice) Mkdir(bundleID, remotePath string, parents bool) error
 		return err
 	}
 	if parents {
-		return os.MkdirAll(remotePath, 0755)
+		return os.MkdirAll(remotePath, 0750)
 	}
-	return os.Mkdir(remotePath, 0755)
+	return os.Mkdir(remotePath, 0750)
 }
 
 func (s *SimulatorDevice) Rm(bundleID, remotePath string, recursive bool) error {

--- a/pkg/avc2mp4/mp4writer.go
+++ b/pkg/avc2mp4/mp4writer.go
@@ -42,7 +42,8 @@ func Convert(avcData []byte, output io.WriteSeeker) (*ConvertResult, error) {
 	firstTs := units[0].timestampUs
 	lastTs := units[len(units)-1].timestampUs
 	var duration time.Duration
-	if delta := lastTs - firstTs; lastTs > firstTs && delta <= math.MaxInt64 {
+	const maxDurationMicros = uint64(math.MaxInt64) / uint64(time.Microsecond)
+	if delta := lastTs - firstTs; lastTs > firstTs && delta <= maxDurationMicros {
 		duration = time.Duration(delta) * time.Microsecond
 	}
 

--- a/pkg/avc2mp4/mp4writer.go
+++ b/pkg/avc2mp4/mp4writer.go
@@ -3,6 +3,7 @@ package avc2mp4
 import (
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"github.com/yapingcat/gomedia/go-mp4"
@@ -40,7 +41,10 @@ func Convert(avcData []byte, output io.WriteSeeker) (*ConvertResult, error) {
 
 	firstTs := units[0].timestampUs
 	lastTs := units[len(units)-1].timestampUs
-	duration := time.Duration(lastTs-firstTs) * time.Microsecond
+	var duration time.Duration
+	if delta := lastTs - firstTs; lastTs > firstTs && delta <= math.MaxInt64 {
+		duration = time.Duration(delta) * time.Microsecond
+	}
 
 	return &ConvertResult{
 		FrameCount: len(units),

--- a/utils/image_test.go
+++ b/utils/image_test.go
@@ -17,7 +17,7 @@ func makeTestPng(t *testing.T, width, height int) []byte {
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
 	for y := range height {
 		for x := range width {
-			img.Set(x, y, color.RGBA{uint8(x), uint8(y), 0, 255})
+			img.Set(x, y, color.RGBA{uint8(x & 0xff), uint8(y & 0xff), 0, 255}) //nolint:gosec // masked to 0-255
 		}
 	}
 	var buf bytes.Buffer
@@ -203,7 +203,7 @@ func TestConvertPngToJpeg(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
 	for y := range h {
 		for x := range w {
-			img.Set(x, y, color.RGBA{uint8(x), uint8(y), 0, 255})
+			img.Set(x, y, color.RGBA{uint8(x & 0xff), uint8(y & 0xff), 0, 255}) //nolint:gosec // masked to 0-255
 		}
 	}
 


### PR DESCRIPTION
Clears all 10 gosec G301/G306 (permissions) and G115 (integer conversion) findings. gosec 37 → 27, total lint issues 330 → 319.

## Changes

**Permissions**
- `devices/android_fs.go`, `devices/simulator_fs.go`: pulled/pushed file writes `0644` → `0600`
- `devices/simulator_fs.go`: `Mkdir`/`MkdirAll` `0755` → `0750`

**Integer conversions**
- `pkg/avc2mp4/mp4writer.go`: real guard on the `uint64` → `int64` duration conversion (`lastTs > firstTs && delta <= math.MaxInt64`); duration is now zero instead of garbage when timestamps are non-monotonic
- `utils/image_test.go`: mask test pixel values with `& 0xff`
- `devices/ios.go`, `devices/ios/port-forwarding.go`: `//nolint:gosec` — both conversions are already bounds-checked immediately above; gosec doesn't track the guard

## Test plan

- [x] `make lint` — the 10 targeted findings are gone
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./pkg/avc2mp4/... ./utils/... ./devices/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pulled files are now saved with owner-only access for improved local security.
  - Simulator files and directories now use more restrictive permissions.
  - Improved MP4 timestamp handling to prevent duration overflows and incorrect values.
- **Security**
  - Forwarded port validation remains enforced before processing port values.
  - Media control data conversions remain safely bounded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->